### PR TITLE
Close #3: Create CHANGELOG file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,23 @@
+=========
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog`_
+and this project adheres to `Semantic Versioning`_.
+
+.. contents::
+
+Unreleased_
+===========
+
+.. Remove these two lines and one indentation level of the next two lines
+    when you will release the first version.
+    .. _Unreleased:
+        https://github.com/char-lie/stereo-parallel/compare/v0.0.1...HEAD
+
+.. _Keep a Changelog:
+    http://keepachangelog.com/en/1.0.0
+.. _Semantic Versioning:
+    http://semver.org/spec/v2.0.0

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,6 +94,7 @@ Read it to know how to name the next version of the project.
 .. _Semantic Versioning:
     http://semver.org/spec/v2.0.0.html
 .. _squashed and merged:
-    https://help.github.com/articles/about-pull-request-merges/ #squash-and-merge-your-pull-request-commits
+    https://help.github.com/articles/about-pull-request-merges/
+    #squash-and-merge-your-pull-request-commits
 .. _Stereo Parallel:
     https://github.com/char-lie/stereo-parallel/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,6 +56,7 @@ Before merge
 
 * Write new tests if needed.
 * Make sure that all tests pass.
+* Change CHANGELOG_ if needed.
 * Change README_ if needed.
 * Check again grammar and lexicon of description of the pull request.
 
@@ -63,9 +64,23 @@ How to bump version of the project
 ==================================
 
 The project adheres to `Semantic Versioning`_.
+Read it to know how to name the next version of the project.
+
+- Switch to ``master`` branch.
+- Change version in CHANGELOG_ file,
+  commit the change with ``Stereo Parallel ${VERSION}`` tag,
+  where ``${VERSION}`` is a new version of the project,
+  but don't push it for now.
+- Create tag with name ``v ${VERSION}``,
+  (``git tag -a "v${VERSION}"`` in ``bash``)
+  with title ``Stereo Parallel ${VERSION}``,
+  and add corresponding section of CHANGELOG_ to tag description.
+- Push your changes using (``git push --follow-tags`` in ``bash``).
 
 .. _bug label:
     https://github.com/char-lie/stereo-parallel/labels/bug
+.. _CHANGELOG:
+    https://github.com/char-lie/stereo-parallel/blob/master/CHANGELOG.rst
 .. _Code of Conduct:
     https://github.com/char-lie/stereo-parallel/blob/master/CODE_OF_CONDUCT.md
 .. _Keep a Changelog:

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Stereo Parallel
 ===============
 
+.. contents::
+
 Contributing
 ============
 


### PR DESCRIPTION
CHANGELOG file is a very useful thing.
As a developer, sometimes I need to know,
when some features were created,
without jumping with `git blame -c` or `git log --follow`
(I could change name of some classes after a while).
As a user, I need to know whether it's a nice idea
to use a new version of some library without comparing
documentation of different versions.
Also I need a guarantee that my code will not be broken
with new release of the library.
[SemVer](https://semver.org) helps with this.
If a library has a major version greater than zero,

- removal of any features or behavior change of existent ones
  should lead to bump of major version;
- new features should go with new minor version;
- bug fixes, that don't change API, change patch version.

Simple enough.
If major version is zero, then minor version plays role of major,
and patch plays role of both minor and patch version.
When only patch version is non-zero,
any version changes affect it until contributors
will bump minor or major version.

Seems like this should work very nice
after the first major version release.
Though, when different parts of public API
deprecated (and then deleted) frequently,
major version of a library grows fast.
As the result, we may will be able observe `Stereo Parallel 35`,
and unlikely to support the first on even tenth version
(fixing bugs and adding new features).
Well, when this will happen, I'll think about another versioning.
For example, [CalVer](https://calver.org) (Calendar Versioning).

I don't know whether I really need table of contents
for the CHANGELOG, but let it be.
Headers, which are specified in table of contents,
are clickable and have a backward reference to table of contents
(at least, on GitHub).
Though, headings in CHANGELOG will refer to comparison pages
between current and previous tag,
because I did so.
Sometimes it's needed to see full difference
between two neighboring versions.
Table of contents does not break this, so I'm happy with it.

Now we have a CHANGELOG and it's needed to support it
when someone makes changes to the project.
Specify this in CONTRIBUTING file.

Tagging is a convenient mechanism to store versions of projects
written in languages that don't support versioning.
Also it's very handy to download archive with corresponding tag
from GitHub.

I think, it's a good idea to copy section from CHANGELOG
to description of corresponding tag.
I've never used the description of tag,
but it sounds better than nothing.

I propose to write project name in bump commit title
to show explicitly that the version of the main project was changed,
not its dependencies'.

Oh, looks like I've pressed `Ctrl+J` in VIM
when sorted the list of links in CONTRIBUTING file,
and haven't restored one long URL.
Fix that in this commit.
It's not a crime to not create a separate issue for this, is it?

Have almost forgotten one more thing.
README will be big, so automatic generation of table of contents is a
good idea.