### PR TITLE
Close #8: Add main CMakeLists file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,18 @@ and this project adheres to `Semantic Versioning`_.
 Unreleased_
 ===========
 
+Added
+-----
+
+- Project build with CMake_
+
 .. Remove these two lines and one indentation level of the next two lines
     when you will release the first version.
     .. _Unreleased:
         https://github.com/char-lie/stereo-parallel/compare/v0.0.1...HEAD
 
+.. _CMake:
+    https://cmake.org
 .. _Keep a Changelog:
     http://keepachangelog.com/en/1.0.0
 .. _Semantic Versioning:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 3 FATAL_ERROR)
+project(STEREO_PARALLEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,2 @@
-cmake_minimum_required(VERSION 3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(STEREO_PARALLEL)

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,8 @@ To build the project in Linux,
 - go there and call ``cmake`` specifying root as the parameter,
 - build the project using ``cmake -build`` or your build system (``make``?).
 
-.. code:: bash
+.. code-block:: bash
+
     git clone https://github.com/char-lie/stereo-parallel.git
     mkdir stereo-parallel/build
     cd build

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,26 @@ When you modify some files,
 It's explained in answer to
 `How to manage a copyright notice in an open source project?`_.
 
+Build the project
+=================
+
+The project uses CMake_ of version 3 and higher.
+To build the project in Linux,
+
+- clone it,
+- create a directory to build the project in,
+- go there and call ``cmake`` specifying root as the parameter,
+- build the project using ``cmake -build`` or your build system (``make``?).
+
+.. code:: bash
+    git clone https://github.com/char-lie/stereo-parallel.git
+    mkdir stereo-parallel/build
+    cd build
+    cmake ..
+    cmake -build .
+
+.. _Cmake:
+    https://cmake.org
 .. _CONTRIBUTING:
     https://github.com/char-lie/stereo-parallel/blob/master/CONTRIBUTING.md
 .. _Code of Conduct:

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ To build the project in Linux,
     cmake ..
     cmake -build .
 
-.. _Cmake:
+.. _CMake:
     https://cmake.org
 .. _CONTRIBUTING:
     https://github.com/char-lie/stereo-parallel/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Add CMakeLists.txt file
=======================

CMake is a cool and widespread (https://cmake.org/success/) tool
for building and testing software.
Dispite the `C` prefix, it can also be used for
`C++` and `CUDA`
(starting with 3.11
 https://cmake.org/cmake/help/v3.11/command/project.html)
as well.

Though, when project grows, `CMakeLists.txt` files become messy
(at least, I'm getting lost in them).
That's why I'll create them carefully and slowly, documenting each step.
Let's start.

I should specify minimal CMake version
required to build the project.
Nice `CUDA` support is available only with CMake 3.11,
though Ubuntu 14 and 16 have only 3.5,
https://packages.ubuntu.com/trusty/cmake3
https://packages.ubuntu.com/xenial/cmake
and Ubuntu 18 (which I use) has CMake 3.10
https://packages.ubuntu.com/bionic/cmake

Debian Jessie (released in 2015) has CMake 3.0
https://packages.debian.org/ru/jessie/cmake
Debian Stretch (released in 2017) has CMake 3.7 available in repository
https://packages.debian.org/ru/stretch/cmake

Fedora 26 has CMake 3.8 package
https://fedora.pkgs.org/26/fedora-x86_64/cmake-3.8.2-1.fc26.x86_64.rpm.html

I can use CMake 3.0 to not make users having modern versions
of mentioned operating systems compile CMake from source.
Luckily for me, CMake 3.0 already has a script `FindCUDA`
to locate NVIDIA CUDA C tools
https://cmake.org/cmake/help/v3.0/module/FindCUDA.html
I should use it.
I wanted to use 2.8 before, because have copied it from examples,
and now I've changed my mind.

There is another interesting thing:
Kitware that owns CMake also has a VTK project
for 3D data visualization
https://www.vtk.org
Let's see how they specify CMake version
https://github.com/Kitware/VTK/blob/c36289f159c8d70cdbad89d5c9ff2b0e21f1175a/CMakeLists.txt#L1
Looks cool: they not only specify minimal version,
but maximal one too.
Though, the feature is available only from version 3.12
https://cmake.org/cmake/help/v3.12/command/cmake_minimum_required.html

I can specify project name there, but for what reason?
https://cmake.org/cmake/help/v3.0/command/project.html
First, it's available only from version 3.0.
Also, it allows not only to have another environment variable,
but to set a version of the project:
major, minor, patch and tweak parts.
Nice!
Name of the project is `STEREO_PARALLEL`.
I can check whether it works by typing the following in `CMakeLists.txt`

```
message("${STEREO_PARALLEL_SOURCE_DIR}")
```

It prints path to root dir of the project
among with another information.

I've set minimal required CMake version to `3`,
ran `cmake ..` and got

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
cmake_minimum_required could not parse VERSION "3".

-- Configuring incomplete, errors occurred!
See also
".../stereo-parallel/build/CMakeFiles/CMakeOutput.log".
```

I should have specified version `3.0`, not simply `3`.

Add build instructions
======================

It's time to write how to build the project.
I've googled and found an example of README file in RST format
that has code blocks
https://github.com/jakubroztocil/httpie/blob/master/README.rst
I need it to have a pretty design for example of project build
in README file.

Also I've found out that name of link alias is case insensitive.
I can use `CMake_` in text and `.. _cmake: https://cmake.org`
to specify hyperlink.
Though, I prefer `.. _CMake: https://cmake.org`

Populate CHANGELOG with CMake entry
===================================

I've added CMake configuration file for project build.
Not sure if this information is really that useful,
but I want to add it to the CHANGELOG.

Gathering commit messages
=========================

Tired of gathering several commit messages
using Web UI of GitHub pull request:
when you click `Squash and Merge`,
it generates commit description
as a combination of all commits in current branch.
It's not so cool as to get these messages using terminal.

At the moment I don't have several merges at the same time
(will this affect the idea?),
so I can use `git cherry` to find the first commit in current branch,
which is not in `master` branch.
I need the first commit, which is in the last line of the output;
`tail -1` will help.
Its output contains two columns:
the first contains `+` or `-` and the second one contains hashes
of commits.
`cut -d " " -f 2` will fetch the second column,
taking into account that delimiter is space.
Resulting command is

```
$ git cherry | tail -1 | cut -d " " -f 2
ac52648845a79de2add1a324a6a2677895273213
```

Titles and messages of commits can be fetched from `git log`.
It has a `--pretty` flag that accepts custom format:
`%s` is for a title, `%n` is a new line and `%b` is a commit text
https://git-scm.com/docs/pretty-formats
Here is a command to fetch needed information

```
git log --reverse --pretty=format:"**%s**%n%n%b" \
  1dfffe31fd1ed0a1edf62f778104ade501feaf98..HEAD
```