### PR TITLE
Close #10: Initialize unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,3 +135,4 @@ script:
   - cd build
   - cmake ..
   - cmake --build .
+  - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,10 @@ matrix:
 before_install:
     - eval "${MATRIX_EVAL}"
 
+before_script:
+    - sudo apt-get update
+    - sudo apt-get install -y libboost-test-dev
+
 script:
   - mkdir build
   - cd build

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 -----
 
 - Project build with CMake_
+- Project testing with ctest_
 
 .. Remove these two lines and one indentation level of the next two lines
     when you will release the first version.
@@ -24,6 +25,8 @@ Added
 
 .. _CMake:
     https://cmake.org
+.. _ctest:
+    https://cmake.org/cmake/help/v3.0/manual/ctest.1.html
 .. _Keep a Changelog:
     http://keepachangelog.com/en/1.0.0
 .. _Semantic Versioning:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ The format is based on `Keep a Changelog`_
 and this project adheres to `Semantic Versioning`_.
 
 .. contents::
+    :backlinks: none
 
 Unreleased_
 ===========

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,6 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(STEREO_PARALLEL)
+
+enable_testing()
+
+add_subdirectory(tests)

--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,24 @@ To build the project in Linux,
     cmake ..
     cmake --build .
 
+After build, it's recommended to run tests
+in order to make sure that all works fine.
+This can be done by executing ctest_ in build directory.
+Here is a bash script for download, build and test
+
+.. code-block:: bash
+
+    git clone https://github.com/char-lie/stereo-parallel.git
+    mkdir stereo-parallel/build
+    cd build
+    cmake ..
+    cmake --build .
+    ctest
+
 .. _CMake:
     https://cmake.org
+.. _ctest:
+    https://cmake.org/cmake/help/v3.0/manual/ctest.1.html
 .. _CONTRIBUTING:
     https://github.com/char-lie/stereo-parallel/blob/master/CONTRIBUTING.md
 .. _Code of Conduct:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+find_package(Boost 1.54 REQUIRED COMPONENTS unit_test_framework)
+
+add_executable(test_executable api.cpp)
+target_include_directories(test_executable PRIVATE ${BOOST_INCLUDE_DIRS})
+target_link_libraries(test_executable ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+target_compile_definitions(
+    test_executable
+    PRIVATE
+    "BOOST_TEST_DYN_LINK=1"
+    "BOOST_TEST_MODULE=Stereo Parallel tests"
+)
+
+add_test(NAME stereo-parallel COMMAND test_executable)

--- a/tests/api.cpp
+++ b/tests/api.cpp
@@ -1,0 +1,6 @@
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_AUTO_TEST_CASE(compile)
+{
+}


### PR DESCRIPTION
Implement the first test
========================

First, we need to include Boost.Test library.
It's easy.

Then, we need to write at least one test.
Let's use `BOOST_AUTO_TEST_CASE`
https://www.boost.org/doc/libs/1_54_0/libs/test/doc/html/utf/user-guide/test-organization/auto-test-case-template.html
It needs a name. This test will check,
whether the application can be compiled.
Name the test `compile` to describe its sense as good as it's possible.

That's one small test for the project, one giant leap for the project.

Add CMakeLists file for tests
=============================

First, go here to read FAQ of Boost Test library compilation
https://www.boost.org/doc/libs/1_62_0/libs/test/doc/html/boost_test/section_faq.html
It contains an example of CMakeLists.txt file
for the shared libraries variant of the fwamework.
I haven't got an idea of setting `Boost_ADDITIONAL_VERSIONS` variable,
so I avoid this step.
Also, some commands are stored in the root CMakeLists.txt file,
so they are not needed here.

First, we need to find the package by `find_package`
https://cmake.org/cmake/help/v3.0/command/find_package.html
We specify its name, minimal version, and mark it as `REQUIRED`
to fail build if the package will be not found.
Next, we write `COMPONENTS` and enumerate needed components.
We don't need all Boost dependencies -- here we need only
`unit_test_framework`.
I've specified version `1.54`, because it's supported by
Ubuntu Trusty 14.04
https://packages.ubuntu.com/trusty/libboost-all-dev
Fedora 26 has `1.63`
https://fedora.pkgs.org/26/fedora-x86_64/boost-1.63.0-5.fc26.x86_64.rpm.html
Debian Jessie has `1.55`
https://packages.debian.org/ru/jessie/libboost-all-dev
Version `1.54` was released on July 1st, 2013
https://www.boost.org/users/history/

Next, create executable file with test using `add_executable`
https://cmake.org/cmake/help/v3.0/command/add_executable.html
I call it `test_executable` like in Boost FAQ,
and use the only source file `api.cpp`.

To use Boost library, we include its headers.
Compiler needs to know where to get them.
Command `target_include_directories` helps with that
https://cmake.org/cmake/help/v3.0/command/target_include_directories.html
Name of target is a name of the test executable.
Here is a good explanation of what `PRIVATE` and `PUBLIC` means here
https://stackoverflow.com/a/28305481/1305036
If test uses the Boost library,
but another modules that use its headers
don't need to have an access to the Boost library
via those headers of the test, we write `PRIVATE`.
In other case, we should use `PUBLIC`.

Let's link shared libary of the Boost Test to the target
with `target_link_libraries`
https://cmake.org/cmake/help/v3.0/command/target_link_libraries.html

We need to define `BOOST_TEST_DYN_LINK` macro for Boost to know
that we want to use shared library.
Also it's needed to specify name of the module
by `BOOST_TEST_MODULE` macro.
This can be done in CMakeLists.txt file too
by `target_compile_definitions` command
https://cmake.org/cmake/help/v3.0/command/target_compile_definitions.html

At last, we need to add the test for `ctest` to recognize it.
It's not a surprise that the command is called `add_test`
https://cmake.org/cmake/help/v3.0/command/add_test.html
Looks quite simple: set name of the test and command
that needs to be called to run the test.

Add tests directory to main CMakeLists.txt
==========================================

We want to run our tests using `ctest`
https://cmake.org/cmake/help/v3.0/manual/ctest.1.html
It's convenient, because we don't need to care about
how to launch tests based on specific testing framework
used by the project.
So, we just build the project and call `ctest`

```
cmake --build .
ctest
```

To enable this cool feature, `enable_testing` should be called
in the root CMakeLists.txt file
https://cmake.org/cmake/help/v3.0/command/enable_testing.html

Next, we need to add directory with tests
(and CMakeLists.txt file for them)
to the project using `add_subdirectory`
https://cmake.org/cmake/help/v3.0/command/add_subdirectory.html

It works!
Need to add this to README file and Travis CI configuration file.

Add information about ctest to documentation
============================================

I've added CMake to CHANGELOG, so I can add information about ctest too.

I could add code block with just `ctest` command to README,
but it's more convenient to have all commands in one place,
so I've duplicated code block of build without test
and added `ctest` command there.

Add ctest command to Travis CI configuration file
=================================================

Nothing to explain here:
just add `ctest` to the bottom of `.travis.yml`

Make Boost Test library to be installed in Travis CI
====================================================

I've forgotten to install Boost Test library before testing
on Travis CI and got errors
https://travis-ci.org/char-lie/stereo-parallel/builds/435756035
Hope, this will help
https://devsector.wordpress.com/2014/11/09/github-continuous-integration-with-travis-ci/#boost

Remove redundant backlinks from CHANGELOG
=========================================

In commit 1dfffe31fd1ed0a1edf62f778104ade501feaf98
I've noticed my anxiety regarding "clickable" headers.
`:backlinks: none` removed links to table of contents
from headings of sections and now I don't worry about this.
http://docutils.sourceforge.net/docs/ref/rst/directives.html#table-of-contents