### PR TITLE
Close #13: Use clang static code analyzers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,11 @@
+{
+    "Checks": "\
+        *,\
+        -fuchsia*,\
+    ",
+    "WarningsAsErrors": "\
+        *,\
+        -clang-diagnostic-unused-command-line-argument,\
+        -cert-err58-cpp,\
+    ",
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ script:
             -enable-checker cplusplus \
             -enable-checker security \
             -v -v -v" && \
-        BUILD_DIR="${TRAVIS_BUILD_DIR}"
+        BUILD_DIR="${TRAVIS_BUILD_DIR}" && \
         clang_static_analyzer cmake \
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,13 +149,14 @@ script:
     - |
       if [[ $CC == clang* ]]
       then
+        BUILD_DIR="${TRAVIS_BUILD_DIR}"
         clang-static-analyzer cmake \
-            -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=$(realpath ..);" \
+            -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
         clang-static-analyzer cmake --build . && \
-        rm -rf *
       fi
+    - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..
     - cmake --build .
     - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,18 +137,18 @@ before_script:
 script:
     - mkdir build
     - cd build
-    - alias clang_static_analyzer="scan-build
-        --use-cc=`which $CC`
-        --use-c++=`which $CXX`
-        --force-analyze-debug-code
-        -enable-checker core
-        -enable-checker unix
-        -enable-checker cplusplus
-        -enable-checker security
-        -v -v -v"
     - |
       if [[ $CC == clang* ]]
       then
+        alias clang_static_analyzer="scan-build \
+            --use-cc=`which $CC` \
+            --use-c++=`which $CXX` \
+            --force-analyze-debug-code \
+            -enable-checker core \
+            -enable-checker unix \
+            -enable-checker cplusplus \
+            -enable-checker security \
+            -v -v -v" && \
         BUILD_DIR="${TRAVIS_BUILD_DIR}"
         clang_static_analyzer cmake \
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,10 @@ before_install:
 before_script:
     - sudo apt-get update
     - sudo apt-get install -y libboost-test-dev
+
+script:
+    - mkdir build
+    - cd build
     - alias clang-static-analyzer="scan-build
         --use-cc=`which $CC`
         --use-c++=`which $CXX`
@@ -142,10 +146,6 @@ before_script:
         -enable-checker cplusplus
         -enable-checker security
         -v -v -v"
-
-script:
-    - mkdir build
-    - cd build
     - |
       if [[ $CC == clang* ]]
       then

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer cmake --build . && \
+        clang-static-analyzer cmake --build
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,20 +135,20 @@ before_script:
     - sudo apt-get install -y libboost-test-dev
 
 script:
-  - mkdir build
-  - cd build
-  - |
-    if [[ $CC == clang* ]]
-    then
-      echo "Use scan-build"
-      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
-          -enable-checker core -enable-checker unix -enable-checker cplusplus \
-          -enable-checker security -v cmake .. && \
-      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
-          -enable-checker core -enable-checker unix -enable-checker cplusplus \
-          -enable-checker security -v cmake --build .
-    else
-      cmake .. && \
-      cmake --build .
-    fi
-  - ctest
+    - mkdir build
+    - cd build
+    - |
+      if [[ $CC == clang* ]]
+      then
+        echo "Use scan-build"
+        scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
+            -enable-checker core -enable-checker unix -enable-checker cplusplus \
+            -enable-checker security -v cmake .. && \
+        scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
+            -enable-checker core -enable-checker unix -enable-checker cplusplus \
+            -enable-checker security -v cmake --build .
+      else
+        cmake .. && \
+        cmake --build .
+      fi
+    - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer cmake --build
+        clang-static-analyzer cmake --build .
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,16 @@ before_install:
 before_script:
     - sudo apt-get update
     - sudo apt-get install -y libboost-test-dev
+    - shopt -s expand_aliases
+    - alias clang-static-analyzer="scan-build
+        --use-cc=`which $CC`
+        --use-c++=`which $CXX`
+        --force-analyze-debug-code
+        -enable-checker core
+        -enable-checker unix
+        -enable-checker cplusplus
+        -enable-checker security
+        -v -v -v"
 
 script:
     - mkdir build
@@ -140,21 +150,12 @@ script:
     - |
       if [[ $CC == clang* ]]
       then
-        alias clang_static_analyzer="scan-build \
-            --use-cc=`which $CC` \
-            --use-c++=`which $CXX` \
-            --force-analyze-debug-code \
-            -enable-checker core \
-            -enable-checker unix \
-            -enable-checker cplusplus \
-            -enable-checker security \
-            -v -v -v" && \
         BUILD_DIR="${TRAVIS_BUILD_DIR}" && \
-        clang_static_analyzer cmake \
+        clang-static-analyzer cmake \
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang_static_analyzer cmake --build .
+        clang-static-analyzer cmake --build . && \
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,56 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
@@ -76,56 +126,6 @@ matrix:
             - clang-6.0
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-8
-      env:
-        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
 before_install:
     - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer cmake --build . && \
+        clang-static-analyzer cmake --build .
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,9 +139,11 @@ before_script:
         --use-c++=`which $CXX`
         --force-analyze-debug-code
         -enable-checker core
-        -enable-checker unix
         -enable-checker cplusplus
+        -enable-checker deadcode
+        -enable-checker nullability
         -enable-checker security
+        -enable-checker unix
         -v -v -v"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,31 +149,13 @@ script:
     - |
       if [[ $CC == clang* ]]
       then
-        CMAKE_CXX_CLANG_TIDY="clang-tidy;"
-        CMAKE_CXX_CLANG_TIDY+="-warnings-as-errors=*;"
-        CMAKE_CXX_CLANG_TIDY+="-header-filter=$(realpath ..);"
-        scan-build \
-            --use-cc=$CC \
-            --use-c++=$CXX \
-            -enable-checker core \
-            -enable-checker unix \
-            -enable-checker cplusplus \
-            -enable-checker security \
-            -v \
-            cmake \
-            -DCMAKE_CXX_CLANG_TIDY=$CMAKE_CXX_CLANG_TIDY \
+        clang-static-analyzer cmake \
+            -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=$(realpath ..);" \
+            -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        scan-build \
-            --use-cc=/usr/bin/$CC \
-            --use-c++=/usr/bin/$CXX \
-            -enable-checker core \
-            -enable-checker unix \
-            -enable-checker cplusplus \
-            -enable-checker security \
-            -v \
-            cmake --build .
-      else
-        cmake .. && \
-        cmake --build .
+        clang-static-analyzer cmake --build . && \
+        rm -rf *
       fi
+    - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..
+    - cmake --build .
     - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,13 +140,29 @@ script:
     - |
       if [[ $CC == clang* ]]
       then
-        echo "Use scan-build"
-        scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
-            -enable-checker core -enable-checker unix -enable-checker cplusplus \
-            -enable-checker security -v cmake .. && \
-        scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
-            -enable-checker core -enable-checker unix -enable-checker cplusplus \
-            -enable-checker security -v cmake --build .
+        CMAKE_CXX_CLANG_TIDY="clang-tidy;"
+        CMAKE_CXX_CLANG_TIDY+="-warnings-as-errors=*;"
+        CMAKE_CXX_CLANG_TIDY+="-header-filter=$(realpath ..);"
+        scan-build \
+            --use-cc=$CC \
+            --use-c++=$CXX \
+            -enable-checker core \
+            -enable-checker unix \
+            -enable-checker cplusplus \
+            -enable-checker security \
+            -v \
+            cmake \
+            -DCMAKE_CXX_CLANG_TIDY=$CMAKE_CXX_CLANG_TIDY \
+            .. && \
+        scan-build \
+            --use-cc=/usr/bin/$CC \
+            --use-c++=/usr/bin/$CXX \
+            -enable-checker core \
+            -enable-checker unix \
+            -enable-checker cplusplus \
+            -enable-checker security \
+            -v \
+            cmake --build .
       else
         cmake .. && \
         cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,16 +137,17 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - if [ $CC == clang* ]
+  - |
+    if [ $CC == clang* ]
     then
-      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
-          -enable-checker core -enable-checker unix -enable-checker cplusplus \
-          -enable-checker security -v cmake ..
-      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
-          -enable-checker core -enable-checker unix -enable-checker cplusplus \
+      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX
+          -enable-checker core -enable-checker unix -enable-checker cplusplus
+          -enable-checker security -v cmake .. && \
+      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX
+          -enable-checker core -enable-checker unix -enable-checker cplusplus
           -enable-checker security -v cmake --build .
     else
-      cmake ..
+      cmake .. && \
       cmake --build .
     fi
   - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,11 +140,11 @@ script:
   - |
     if [ $CC == clang* ]
     then
-      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX
-          -enable-checker core -enable-checker unix -enable-checker cplusplus
+      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
+          -enable-checker core -enable-checker unix -enable-checker cplusplus \
           -enable-checker security -v cmake .. && \
-      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX
-          -enable-checker core -enable-checker unix -enable-checker cplusplus
+      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
+          -enable-checker core -enable-checker unix -enable-checker cplusplus \
           -enable-checker security -v cmake --build .
     else
       cmake .. && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,56 +7,6 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-8
-      env:
-        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
@@ -126,6 +76,56 @@ matrix:
             - clang-6.0
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
 before_install:
     - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,15 @@ before_install:
 before_script:
     - sudo apt-get update
     - sudo apt-get install -y libboost-test-dev
+    - alias clang-static-analyzer="scan-build
+        --use-cc=`which $CC`
+        --use-c++=`which $CXX`
+        --force-analyze-debug-code
+        -enable-checker core
+        -enable-checker unix
+        -enable-checker cplusplus
+        -enable-checker security
+        -v -v -v"
 
 script:
     - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,16 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - cmake ..
-  - cmake --build .
+  - if [ $CC == clang* ]
+    then
+      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
+          -enable-checker core -enable-checker unix -enable-checker cplusplus \
+          -enable-checker security -v cmake ..
+      scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
+          -enable-checker core -enable-checker unix -enable-checker cplusplus \
+          -enable-checker security -v cmake --build .
+    else
+      cmake ..
+      cmake --build .
+    fi
   - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ before_script:
 script:
     - mkdir build
     - cd build
-    - alias clang-static-analyzer="scan-build
+    - alias clang_static_analyzer="scan-build
         --use-cc=`which $CC`
         --use-c++=`which $CXX`
         --force-analyze-debug-code
@@ -150,11 +150,11 @@ script:
       if [[ $CC == clang* ]]
       then
         BUILD_DIR="${TRAVIS_BUILD_DIR}"
-        clang-static-analyzer cmake \
+        clang_static_analyzer cmake \
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer cmake --build .
+        clang_static_analyzer cmake --build .
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,8 +138,9 @@ script:
   - mkdir build
   - cd build
   - |
-    if [ $CC == clang* ]
+    if [[ $CC == clang* ]]
     then
+      echo "Use scan-build"
       scan-build --use-cc=/usr/bin/$CC --use-c++=/usr/bin/$CXX \
           -enable-checker core -enable-checker unix -enable-checker cplusplus \
           -enable-checker security -v cmake .. && \

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,6 +7,53 @@ First of all, read the `Code of Conduct`_.
 
 .. contents::
 
+Running tests
+=============
+
+When you write something new,
+you should check that your code doesn't break anything
+and complies with coding standards used in the project.
+
+In order to check the style,
+run `Clang Static Analyzer`_ and `Clang-Tidy`_.
+It's feasible to create an alias for the static analyzer
+
+.. code-block:: bash
+    mkdir build
+    cd build
+    alias clang-static-analyzer="scan-build \
+          --use-cc=`which cc` \
+          --use-c++=`which cpp` \
+          --force-analyze-debug-code \
+          -enable-checker core \
+          -enable-checker unix \
+          -enable-checker cplusplus \
+          -enable-checker security \
+          -v -v -v"
+    clang-static-analyzer cmake \
+         -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=$(realpath ..);" \
+         -DCMAKE_BUILD_TYPE=Debug \
+         ..
+    clang-static-analyzer cmake --build .
+
+Warnings are allowed (but try to avoid them if possible),
+errors will fail the CI.
+
+Note that you should use ``scan-build`` for both
+CMake project generation and compilation.
+Next, you should clear content of the build folder,
+because now it doesn't contain runnable test,
+rebuild the project and run tests
+
+.. code-block:: bash
+    rm -rf *
+    cmake \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" \
+          ..
+    cmake --build .
+    ctest
+
 Pull request processing
 =======================
 
@@ -97,4 +144,8 @@ Read it to know how to name the next version of the project.
     https://help.github.com/articles/about-pull-request-merges/
     #squash-and-merge-your-pull-request-commits
 .. _Stereo Parallel:
-    https://github.com/char-lie/stereo-parallel/
+    https://github.com/char-lie/stereo-parallel
+.. _Clang Static Analyzer:
+    https://clang-analyzer.llvm.org
+.. _Clang-Tidy:
+    http://clang.llvm.org/extra/clang-tidy

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,6 +19,7 @@ run `Clang Static Analyzer`_ and `Clang-Tidy`_.
 It's feasible to create an alias for the static analyzer
 
 .. code-block:: bash
+
     mkdir build
     cd build
     alias clang-static-analyzer="scan-build \
@@ -46,6 +47,7 @@ because now it doesn't contain runnable test,
 rebuild the project and run tests
 
 .. code-block:: bash
+
     rm -rf *
     cmake \
           -DCMAKE_BUILD_TYPE=Debug \

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,7 +48,6 @@ rebuild the project and run tests
 
 .. code-block:: bash
 
-    rm -rf *
     cmake \
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" \


### PR DESCRIPTION
Introduction
============

It's hard for me to change configuration file for CI,
because after each change I need to wait
for installation of needed packages on clean CI environment.
When something trivial fails after several minutes of waiting,
I'm feeling very sad.
You just forget to add a semicolon,
wait for ten minutes and get this error.
It's painful.
Though, it's gone and I'd like to tell you how it works.

Use clang static analyzers in Travis CI configuration file
==========================================================

From LLVM mailing list I understand
that `Clang Static Analyzer` (scan-build)
and `Clang-Tidy` (clang-tidy) perform different checks,
so it's good to have them both.
http://lists.llvm.org/pipermail/cfe-dev/2015-September/044966.html

`Clang Static Analyzer` is provided with clang,
as it may be obvious from its name.
In Ubuntu I had to install it

```bash
apt install clang-tools
```

While in Travis CI it was installed with clang.
Perfect!

I need to run this diagnostics only when clang installed.
Just check it with `$CC == clang*`.
Be careful: don't use `"clang*"`,
because it will match literally the string `clang*`,
not any string starting with `clang`
https://stackoverflow.com/a/2172367/1305036

In order to create long commands in YAML file,
I should either use `|` and then write commands
like in an ordinary bash script
or write the script in one line
and then split it into several lines.
The difference between these two approaches is following:
in the first case (`|`) script will be executed as is,
while in the second case its strings will be concatenated
and then executed, so no slash symbols required
https://stackoverflow.com/a/38790045/1305036

Use Clang Static Analyzer in Travis CI
======================================

Clang Static Analyzer is a nice tool, but it's hard for me to use it.

First, it's named `scan-build`.
Not really obvious.

Second, I need to specify `C` and `CXX` compiler I want it to use,
because it handles `CCC_CC` and `CCC_CXX` environment variables,
ignoring `CC` and `CXX`
https://baptiste-wicht.com/posts/2014/04/install-use-clang-static-analyzer-cmake.html
Right parameters to use are `--use-cc` and `--use-c++`
https://github.com/ttroy50/cmake-examples/tree/master/04-static-analysis/clang-analyzer#scan-build

Third, I have to enumerate checks I need and I cannot just write `*`.
I should write `-enable-checker` before name of each used checker.
Checkers I'm interested in are `core`, `cplusplus`, `deadcode`,
`nullability`, `security` and `unix`
https://clang-analyzer.llvm.org/available_checks.html

At last, I should call it twice:
to configure CMake project and to build it!
https://stackoverflow.com/a/21785566/1305036

It's recommended to build the project in `debug` mode
when analyzing with `scan-build` in order to enable assertions.
Also, it's possible to use `--force-analyze-debug-code` instead.
I take two just to be sue
https://clang-analyzer.llvm.org/scan-build.html#recommended_debug

I want to have as verbose output as it's possible,
so I also add `-v -v -v`.
Don't know, why do they made it working like this instead of `-vvv`,
but let it be
https://clang-analyzer.llvm.org/scan-build.html#recommended_verbose

I've found example of its usage in Travis CI here
https://github.com/robotsthatdream/cafer/blob/fa614347e44e045fcf1a87252dbe73fe3321e391/.travis.yml

Create an alias for scan-build
------------------------------

`scan-build` command with all parameters is too long.
Also, I should use it twice:
for project configuration and for project build.
It's convenient to create an alias for it.

Though, when I've tried to use it, Travis CI said

```
clang-static-analyzer: command not found
```

After failed builds and tens of googled pages
I've found the solution.
I need to add an ability to use aliases in Travis CI
by `shopt -s expand_aliases` command
https://github.com/travis-ci/travis-ci/issues/2552#issuecomment-200640335

Add clang-tidy check to Travis CI
=================================

Travis CI has CMake 3.9.2, and clang-tidy support was started from 3.6
https://cmake.org/cmake/help/v3.6/variable/CMAKE_LANG_CLANG_TIDY.html
I like you, Travis CI!
This means, that I simply add
`-DCMAKE_CXX_CLANG_TIDY="clang-tidy`
parameter to my CMake project configuration and it works.
Value of this parameter
is a list of `clang-tidy` parameters separated by semicolon,
including actual `clang-tidy` command name.

Let's avoid check of third-party libraries
by adding `-header-filter=${TRAVIS_BUILD_DIR}`
to parameters of `clang-tidy`.
Simply add it to the string with parameters
`-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=$(realpath ..)`
https://sarcasm.github.io/notes/dev/clang-tidy.html#cmake-integration

Oh no.
Travis CI doesn't have `realpath` and throws an error
https://travis-ci.org/char-lie/stereo-parallel/jobs/437311497

```
The program 'realpath' is currently not installed. To run 'realpath'
please ask your administrator to install the package 'realpath'
```

Okay, I'll use `TRAVIS_BUILD_DIR` environment variable instead
https://docs.travis-ci.com/user/environment-variables

Now the parameter looks like
`-DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${TRAVIS_BUILD_DIR}`

Add clang-tidy configuration file
---------------------------------

You can store configuration for clang-tidy in a separate file
named `.clang-tidy`
http://clang.llvm.org/extra/clang-tidy

I enable all checks by `*`, and treat all warnings as errors first.

I get `clang-diagnostic-unused-command-line-argument`
in arguments passed by CMakeLists file.
If I remove definition of
`BOOST_TEST_DYN_LINK` and `BOOST_TEST_MODULE` macros
from CMakeLists.txt file of tests, compilation fails,
so I've downgraded the error to warning

```
warning: .../stereo-parallel/build/tests/: 'linker' input unused [clang-diagnostic-unused-command-line-argument]
warning: argument unused during compilation: '-D BOOST_TEST_DYN_LINK=1' [clang-diagnostic-unused-command-line-argument]
warning: argument unused during compilation: '-D BOOST_TEST_MODULE=Stereo Parallel tests' [clang-diagnostic-unused-command-line-argument]
warning: argument unused during compilation: '-c' [clang-diagnostic-unused-command-line-argument]
warning: argument unused during compilation: '-g' [clang-diagnostic-unused-command-line-argument]
```

I had `cert-err58-cpp` in the only test of the project.
I googled the issue for several evenings,
and came to conclusion that it's better to add this error
to exceptions of `WarningsAsErrors` list as well

```
.../stereo-parallel/tests/api.cpp:4:1: warning: initialization of 'compile_registrar40' with static storage duration may throw an exception that cannot be caught [cert-err58-cpp]
BOOST_AUTO_TEST_CASE(compile)
^
/usr/include/boost/test/unit_test_suite.hpp:209:9: note: expanded from macro 'BOOST_AUTO_TEST_CASE'
        BOOST_AUTO_TEST_CASE_NO_DECOR,                                  \
        ^
/usr/include/boost/test/tree/auto_registration.hpp:40:17: note: possibly throwing constructor declared here
                auto_test_unit_registrar( test_case* tc, decorator::collector& decorators, counter_t exp_fail = 0 );
                ^
/usr/bin/clang++ -DBOOST_TEST_DYN_LINK=1 -DBOOST_TEST_MODULE=Stereo Parallel tests -g -o CMakeFiles/test_executable.dir/api.cpp.o -c .../stereo-parallel/tests/api.cpp
```

Looks like that's all, but suddenly there appeared a strange error
`fuchsia-default-arguments`

```
.../stereo-parallel/tests/api.cpp:4:1: error: calling a function that uses a default argument is disallowed [fuchsia-default-arguments,-warnings-as-errors]
BOOST_AUTO_TEST_CASE(compile)
^
/usr/include/boost/test/unit_test_suite.hpp:209:9: note: expanded from macro 'BOOST_AUTO_TEST_CASE'
        BOOST_AUTO_TEST_CASE_NO_DECOR,                                  \
        ^
/usr/include/boost/function/function_template.hpp:1056:13: note: default parameter was declared here
           ,typename boost::enable_if_c<
```

It's strange, because...is it bad to use default arguments
in C++ code in 2018?
Okay, let's read about it
https://clang.llvm.org/extra/clang-tidy/checks/fuchsia-default-arguments.html
This clarified almost nothing for me,
except now I'm sure that it really doesn't like default arguments.
What is `Fuchsia`?
It's an OS make by Google
https://fuchsia.googlesource.com
Nice.
The warning belons to this project.
This means that I can disable warnings of `fuchsia`.

Use strict warnings during compilation
======================================

First, we should clean the build directory,
because tests compiled with `scan-build` don't run.
Then, build the project.
Use not only `all` warnings, but also `extra`
and `pedantic` to check that the code follows ISO C++.
Add `Werror` to fail on compiler warnings.
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

Add test run instructions to contributing guide
-----------------------------------------------

It's mandatory for contributors 
to know how to check result of their work
before pushing the code and triggering CI.