### PR TITLE
Close #27: Fix link to contribution guide in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Here is a bash script for download, build and test
 .. _ctest:
     https://cmake.org/cmake/help/v3.0/manual/ctest.1.html
 .. _CONTRIBUTING:
-    https://github.com/char-lie/stereo-parallel/blob/master/CONTRIBUTING.md
+    https://github.com/char-lie/stereo-parallel/blob/master/CONTRIBUTING.rst
 .. _Code of Conduct:
     https://github.com/char-lie/stereo-parallel/blob/master/CODE_OF_CONDUCT.md
 .. _How to manage a copyright notice in an open source project?:


### PR DESCRIPTION
I've accidentally used `md` extension instead of `rst`.
Fix is really simple.