### PR TITLE
Close #39: Fix source files directory in CodeDocs configuration file

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -1,2 +1,2 @@
 DOXYFILE = docs/Doxyfile.in
-INPUT = src
+INPUT = input


### PR DESCRIPTION
I've noticed that online documentation of the project
https://codedocs.xyz/char-lie/stereo-parallel/
doesn't contain description of `Image` structure.

In log file I've found

```
Found config file .codedocs, loading...
Found DOXYFILE docs/Doxyfile.in, importing configuration...
warning: tag INPUT: input source `src' does not exist
warning: source src is not a readable file or directory... skipping.
```

Perfect.
I've forgotten to change the path in file `.codedocs`.
Originally, it was created in 673d0804c998a7691aec2957b7980c5bbcbe3e21.
It was expected that source files will be located in `src` directory.
Though, finally they were created in `include` folder
because of clang-tidy e16f4c08b2a38d570a2676348520fec78afdbc06.

Not cool,
because I can check documentation build only from `master` branch.