### PR TITLE
Close #41: Refix source files directory in CodeDocs configuration file

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -1,2 +1,2 @@
 DOXYFILE = docs/Doxyfile.in
-INPUT = input
+INPUT = include


### PR DESCRIPTION
It's a fail.
I've used `input` instead of `include` in
05682604def82da3505bc6aadd677e90cf3e443f.
I guess, this time it's alright.

Should not forget to delete pull request id from the end of title of the commit.
I've already forgotten this twice:
05682604def82da3505bc6aadd677e90cf3e443f
c6f7fd797a0b57678fa4db124a0277c0f4d9463d