### PR TITLE
Close #43: Implement basic functionality for Image structure

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,5 +8,6 @@
         -clang-diagnostic-unused-command-line-argument,\
         -cert-err58-cpp,\
         -google-runtime-int,\
+        -cppcoreguidelines-pro-type-vararg,\
     ",
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,19 @@ Added
 - Project build with CMake_.
 - Project testing with ctest_.
 - `Image` structure to store information about images.
+  Contains
+
+  - `width` of an image,
+  - `height` of an image,
+  - `max_value` limit for intensity,
+  - `data` array of intensities of pixels in row-major order.
+
 - `Pixel` structure to represent position of a pixel.
+  Contains
+
+  - `row` (vertical offset) of a pixel,
+  - `column` (horizontal offset) of a pixel.
+
 - `image_valid` function to check validity of `Image`.
 - `get_pixel_index` to calculate index of given pixel in 1D intensities array.
 - `get_pixel_value` to fetch intensity of given pixel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,14 @@ Unreleased_
 Added
 -----
 
-- Project build with CMake_
-- Project testing with ctest_
-- `Image` structure to store information about images
+- Project build with CMake_.
+- Project testing with ctest_.
+- `Image` structure to store information about images.
+- `Pixel` structure to represent position of a pixel.
+- `image_valid` function to check validity of `Image`.
+- `get_pixel_index` to calculate index of given pixel in 1D intensities array.
+- `get_pixel_value` to fetch intensity of given pixel
+  from 1D intensities array.
 
 .. Remove these two lines and one indentation level of the next two lines
     when you will release the first version.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,23 +18,24 @@ Added
 
 - Project build with CMake_.
 - Project testing with ctest_.
-- `Image` structure to store information about images.
+- ``Image`` structure to store information about images.
   Contains
 
-  - `width` of an image,
-  - `height` of an image,
-  - `max_value` limit for intensity,
-  - `data` array of intensities of pixels in row-major order.
+  - ``width`` of an image,
+  - ``height`` of an image,
+  - ``max_value`` limit for intensity,
+  - ``data`` array of intensities of pixels in row-major order.
 
-- `Pixel` structure to represent position of a pixel.
+- ``Pixel`` structure to represent position of a pixel.
   Contains
 
-  - `row` (vertical offset) of a pixel,
-  - `column` (horizontal offset) of a pixel.
+  - ``row`` (vertical offset) of a pixel,
+  - ``column`` (horizontal offset) of a pixel.
 
-- `image_valid` function to check validity of `Image`.
-- `get_pixel_index` to calculate index of given pixel in 1D intensities array.
-- `get_pixel_value` to fetch intensity of given pixel
+- ``image_valid`` function to check validity of ``Image``.
+- ``get_pixel_index`` to calculate index of given pixel
+  in 1D intensities array.
+- ``get_pixel_value`` to fetch intensity of given pixel
   from 1D intensities array.
 
 .. Remove these two lines and one indentation level of the next two lines

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1533,7 +1533,7 @@ FORMULA_TRANSPARENT    = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -19,8 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-add_library(image image.hpp)
-set_target_properties(image PROPERTIES LINKER_LANGUAGE CXX)
+add_library(image image.cpp)
 target_include_directories(
     image PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/include/image.cpp
+++ b/include/image.cpp
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "image.hpp"
+
+bool image_valid(const struct Image& image)
+{
+    if (!image.max_value || !image.width || !image.height)
+    {
+        return false;
+    }
+    for (unsigned i = 0; i < image.width * image.height; ++i)
+    {
+        if (image.data[i] > image.max_value)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+ULONG get_pixel_index(const struct Image& image, struct Pixel pixel)
+{
+    return image.width * pixel.row + pixel.column;
+}
+
+ULONG get_pixel_value(const struct Image& image, struct Pixel pixel)
+{
+    return image.data[get_pixel_index(image, pixel)];
+}

--- a/include/image.cpp
+++ b/include/image.cpp
@@ -25,7 +25,7 @@
 
 bool image_valid(const struct Image& image)
 {
-    if (!image.max_value || !image.width || !image.height)
+    if (image.max_value == 0 || image.width == 0 || image.height == 0)
     {
         return false;
     }

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -29,8 +29,6 @@
 
 #include <vector>
 
-using std::vector;
-
 /**
  * \brief Unsigned long type alias
  * to use the same name on CPU and GPU.
@@ -40,7 +38,7 @@ using ULONG = unsigned long;
  * \brief Unsigned long array type alias
  * to use the same name on CPU and GPU.
  */
-using ULONG_ARRAY = vector<ULONG>;
+using ULONG_ARRAY = std::vector<ULONG>;
 
 /**
  * \brief Structure to represent image on both CPU and GPU.

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -100,4 +100,31 @@ struct Pixel
     ULONG column;
 };
 
+/**
+ * \brief Check validity of an image.
+ *
+ * Image should contain at least one pixel,
+ * maximal intensity should be greater than zero,
+ * and neither intensity should exceed specified maximal value.
+ */
+bool image_valid(const struct Image& image);
+/**
+ * \brief Get position of the pixel in data array of the image.
+ *
+ * Despite instensities of pixels are stored in 1D array Image::data,
+ * it's convenient to access them using their coordinates.
+ * That's why the function for coordinates' conversion is needed.
+ *
+ * Result of accessing non-existent value
+ * depends on ::ULONG_ARRAY.
+ */
+ULONG get_pixel_index(const struct Image& image, struct Pixel pixel);
+/**
+ * \brief Get intensity of the pixel in the image.
+ *
+ * Simply call ::get_pixel_index and take a value with returned index
+ * from Image::data.
+ */
+ULONG get_pixel_value(const struct Image& image, struct Pixel pixel);
+
 #endif

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -27,7 +27,9 @@
 #ifndef IMAGE_HPP
 #define IMAGE_HPP
 
-#include <memory>
+#include <vector>
+
+using std::vector;
 
 /**
  * \brief Unsigned long type alias
@@ -35,15 +37,16 @@
  */
 using ULONG = unsigned long;
 /**
- * \brief Unsigned long pointer type alias
+ * \brief Unsigned long array type alias
  * to use the same name on CPU and GPU.
  */
-using ULONG_PTR = std::shared_ptr<ULONG>;
+using ULONG_ARRAY = vector<ULONG>;
 
 /**
  * \brief Structure to represent image on both CPU and GPU.
  */
-struct Image {
+struct Image
+{
     /**
      * \brief Width of the image in pixels.
      */
@@ -53,12 +56,33 @@ struct Image {
      */
     ULONG height;
     /**
+     * \brief Maximal intensity contained in Image::data array.
+     */
+    ULONG max_value;
+    /**
      * \brief Data contained in the image.
      *
      * Image is represented as a grid with intensities of pixels.
      * Intensity is a non-negative integer.
+     *
+     * In order to increase performance
+     * 1D array is used with row-major order:
+     * first, we put elements of the first row one-by-one,
+     * then the second one, and so on
+     *
+     * \f[
+     *  \begin{bmatrix}
+     *      a_{0 0} & a_{0 1} \\
+     *      a_{1 0} & a_{1 1} \\
+     *  \end{bmatrix}
+     *  \mapsto
+     *  \begin{bmatrix}
+     *      a_{0 0} & a_{0 1} &
+     *      a_{1 0} & a_{1 1}
+     *  \end{bmatrix}
+     * \f]
      */
-    ULONG_PTR data;
+    ULONG_ARRAY data;
 };
 
 #endif

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -85,4 +85,19 @@ struct Image
     ULONG_ARRAY data;
 };
 
+/**
+ * Structure that contains position of a pixel.
+ */
+struct Pixel
+{
+    /**
+     * \brief Row (vertical offset) of the pixel.
+     */
+    ULONG row;
+    /**
+     * \brief Column (horizontal offset) of the pixel.
+     */
+    ULONG column;
+};
+
 #endif

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -34,51 +34,51 @@ BOOST_AUTO_TEST_CASE(create_image)
     BOOST_CHECK_EQUAL(image.width, 2);
     BOOST_CHECK_EQUAL(image.height, 1);
     BOOST_CHECK_EQUAL(image.max_value, 1);
-    BOOST_TEST(image.data == vector<ULONG>({0, 1}));
+    BOOST_CHECK(image.data == vector<ULONG>({0, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(check_image_valid)
 {
     struct Image image{2, 1, 1, {0, 1}};
-    BOOST_TEST(image_valid(image));
+    BOOST_CHECK(image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_value)
 {
     struct Image image{2, 1, 1, {0, 2}};
-    BOOST_TEST(!image_valid(image));
+    BOOST_CHECK(!image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_max_value)
 {
     struct Image image{2, 1, 0, {0, 0}};
-    BOOST_TEST(!image_valid(image));
+    BOOST_CHECK(!image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_size)
 {
     struct Image image{0, 0, 1, {}};
-    BOOST_TEST(!image_valid(image));
+    BOOST_CHECK(!image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(check_get_pixel_index)
 {
     struct Image image{2, 2, 3, {3, 2, 1, 0}};
-    BOOST_TEST(image_valid(image));
-    BOOST_TEST(get_pixel_index(image, {0, 0}) == 0);
-    BOOST_TEST(get_pixel_index(image, {0, 1}) == 1);
-    BOOST_TEST(get_pixel_index(image, {1, 0}) == 2);
-    BOOST_TEST(get_pixel_index(image, {1, 1}) == 3);
+    BOOST_CHECK(image_valid(image));
+    BOOST_CHECK(get_pixel_index(image, {0, 0}) == 0);
+    BOOST_CHECK(get_pixel_index(image, {0, 1}) == 1);
+    BOOST_CHECK(get_pixel_index(image, {1, 0}) == 2);
+    BOOST_CHECK(get_pixel_index(image, {1, 1}) == 3);
 }
 
 BOOST_AUTO_TEST_CASE(check_get_pixel_value)
 {
     struct Image image{2, 2, 3, {3, 2, 1, 0}};
-    BOOST_TEST(image_valid(image));
-    BOOST_TEST(get_pixel_value(image, {0, 0}) == 3);
-    BOOST_TEST(get_pixel_value(image, {0, 1}) == 2);
-    BOOST_TEST(get_pixel_value(image, {1, 0}) == 1);
-    BOOST_TEST(get_pixel_value(image, {1, 1}) == 0);
+    BOOST_CHECK(image_valid(image));
+    BOOST_CHECK(get_pixel_value(image, {0, 0}) == 3);
+    BOOST_CHECK(get_pixel_value(image, {0, 1}) == 2);
+    BOOST_CHECK(get_pixel_value(image, {1, 0}) == 1);
+    BOOST_CHECK(get_pixel_value(image, {1, 1}) == 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -30,10 +30,55 @@ BOOST_AUTO_TEST_SUITE(ImageTest)
 
 BOOST_AUTO_TEST_CASE(create_image)
 {
-    struct Image image{2, 1, {0, 1}};
+    struct Image image{2, 1, 1, {0, 1}};
     BOOST_CHECK_EQUAL(image.width, 2);
     BOOST_CHECK_EQUAL(image.height, 1);
+    BOOST_CHECK_EQUAL(image.max_value, 1);
     BOOST_CHECK(image.data == vector<ULONG>({0, 1}));
+}
+
+BOOST_AUTO_TEST_CASE(check_image_valid)
+{
+    struct Image image{2, 1, 1, {0, 1}};
+    BOOST_CHECK(image_valid(image));
+}
+
+BOOST_AUTO_TEST_CASE(image_invalid_value)
+{
+    struct Image image{2, 1, 1, {0, 2}};
+    BOOST_CHECK(!image_valid(image));
+}
+
+BOOST_AUTO_TEST_CASE(image_invalid_max_value)
+{
+    struct Image image{2, 1, 0, {0, 0}};
+    BOOST_CHECK(!image_valid(image));
+}
+
+BOOST_AUTO_TEST_CASE(image_invalid_size)
+{
+    struct Image image{0, 0, 1, {}};
+    BOOST_CHECK(!image_valid(image));
+}
+
+BOOST_AUTO_TEST_CASE(check_get_pixel_index)
+{
+    struct Image image{2, 2, 3, {3, 2, 1, 0}};
+    BOOST_CHECK(image_valid(image));
+    BOOST_CHECK(get_pixel_index(image, {0, 0}) == 0);
+    BOOST_CHECK(get_pixel_index(image, {0, 1}) == 1);
+    BOOST_CHECK(get_pixel_index(image, {1, 0}) == 2);
+    BOOST_CHECK(get_pixel_index(image, {1, 1}) == 3);
+}
+
+BOOST_AUTO_TEST_CASE(check_get_pixel_value)
+{
+    struct Image image{2, 2, 3, {3, 2, 1, 0}};
+    BOOST_CHECK(image_valid(image));
+    BOOST_CHECK(get_pixel_value(image, {0, 0}) == 3);
+    BOOST_CHECK(get_pixel_value(image, {0, 1}) == 2);
+    BOOST_CHECK(get_pixel_value(image, {1, 0}) == 1);
+    BOOST_CHECK(get_pixel_value(image, {1, 1}) == 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -24,13 +24,16 @@
 #include <boost/test/unit_test.hpp>
 #include <image.hpp>
 
+using std::vector;
+
 BOOST_AUTO_TEST_SUITE(ImageTest)
 
 BOOST_AUTO_TEST_CASE(create_image)
 {
-    struct Image image{0, 0, nullptr};
-    BOOST_CHECK_EQUAL(image.width, 0);
-    BOOST_CHECK_EQUAL(image.height, 0);
+    struct Image image{2, 1, {0, 1}};
+    BOOST_CHECK_EQUAL(image.width, 2);
+    BOOST_CHECK_EQUAL(image.height, 1);
+    BOOST_CHECK(image.data == vector<ULONG>({0, 1}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -34,51 +34,51 @@ BOOST_AUTO_TEST_CASE(create_image)
     BOOST_CHECK_EQUAL(image.width, 2);
     BOOST_CHECK_EQUAL(image.height, 1);
     BOOST_CHECK_EQUAL(image.max_value, 1);
-    BOOST_CHECK(image.data == vector<ULONG>({0, 1}));
+    BOOST_TEST(image.data == vector<ULONG>({0, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(check_image_valid)
 {
     struct Image image{2, 1, 1, {0, 1}};
-    BOOST_CHECK(image_valid(image));
+    BOOST_TEST(image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_value)
 {
     struct Image image{2, 1, 1, {0, 2}};
-    BOOST_CHECK(!image_valid(image));
+    BOOST_TEST(!image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_max_value)
 {
     struct Image image{2, 1, 0, {0, 0}};
-    BOOST_CHECK(!image_valid(image));
+    BOOST_TEST(!image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_size)
 {
     struct Image image{0, 0, 1, {}};
-    BOOST_CHECK(!image_valid(image));
+    BOOST_TEST(!image_valid(image));
 }
 
 BOOST_AUTO_TEST_CASE(check_get_pixel_index)
 {
     struct Image image{2, 2, 3, {3, 2, 1, 0}};
-    BOOST_CHECK(image_valid(image));
-    BOOST_CHECK(get_pixel_index(image, {0, 0}) == 0);
-    BOOST_CHECK(get_pixel_index(image, {0, 1}) == 1);
-    BOOST_CHECK(get_pixel_index(image, {1, 0}) == 2);
-    BOOST_CHECK(get_pixel_index(image, {1, 1}) == 3);
+    BOOST_TEST(image_valid(image));
+    BOOST_TEST(get_pixel_index(image, {0, 0}) == 0);
+    BOOST_TEST(get_pixel_index(image, {0, 1}) == 1);
+    BOOST_TEST(get_pixel_index(image, {1, 0}) == 2);
+    BOOST_TEST(get_pixel_index(image, {1, 1}) == 3);
 }
 
 BOOST_AUTO_TEST_CASE(check_get_pixel_value)
 {
     struct Image image{2, 2, 3, {3, 2, 1, 0}};
-    BOOST_CHECK(image_valid(image));
-    BOOST_CHECK(get_pixel_value(image, {0, 0}) == 3);
-    BOOST_CHECK(get_pixel_value(image, {0, 1}) == 2);
-    BOOST_CHECK(get_pixel_value(image, {1, 0}) == 1);
-    BOOST_CHECK(get_pixel_value(image, {1, 1}) == 0);
+    BOOST_TEST(image_valid(image));
+    BOOST_TEST(get_pixel_value(image, {0, 0}) == 3);
+    BOOST_TEST(get_pixel_value(image, {0, 1}) == 2);
+    BOOST_TEST(get_pixel_value(image, {1, 0}) == 1);
+    BOOST_TEST(get_pixel_value(image, {1, 1}) == 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Use 'std::vector' instead of 'std::shared_ptr'
==============================================

It's more convenient to store data array of `Image` as a `vector`
in order to access its elements and ease its construction.

Looks like Boost Test library has no specific tool
for comparison of arrays,
so I'll use a regular `BOOST_CHECK`.
Attempt to use `BOOST_CHECK_EQUAL` led to an error,
because in the case of failure the library cannot display wrong array

```
/usr/include/boost/test/tools/detail/print_helper.hpp:54:18: error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'const std::vector<unsigned long, std::allocator<unsigned long> >')
            ostr << t;
            ~~~~ ^  ~
```

There is an alternative called `BOOST_TEST`,
but it wasn't found
https://travis-ci.org/char-lie/stereo-parallel/jobs/449521868

```
/home/travis/build/char-lie/stereo-parallel/tests/image.cpp:37:5: error: use of undeclared identifier 'BOOST_TEST' [clang-diagnostic-error]
    BOOST_TEST(image.data == vector<ULONG>({0, 1}));
    ^
```

Implement `Pixel` structure
===========================

In a function that will return pixel index by its position on an image
we will need to provide the position.
I'd like to provide a structure instead of two values,
because soon aggregate initialization will allow to use
`get_index(image, {.row = x, .column = y})`,
and this is more clear than `get_index(image, x, y)`.
https://en.cppreference.com/w/cpp/language/aggregate_initialization

Implement Image check and read functions
========================================

Header files usually contain prototypes of functions.
I implement prototypes for image validation, pixel index calculation and
its intensity fetch.
Next, I create corresponding source file with bodies of the functions.

Add Image source file to CMakeLists.txt
=======================================

We no longer need explicit specificaton of linker language,
because source file extension is enough.

Use MathJAX in Doxygen
======================

I use LaTeX code in documentation
by `\f[` to open code block and `\f]` to close it
https://www.stack.nl/~dimitri/doxygen/manual/formulas.html

I should enable `USE_MATHJAX` option in Doxyfile
to render formulas right
https://www.stack.nl/~dimitri/doxygen/manual/config.html#cfg_use_mathjax

Don't use 'using' in global namespace
=====================================

An error occurred during build
https://travis-ci.org/char-lie/stereo-parallel/jobs/449513554

```
/home/travis/build/char-lie/stereo-parallel/include/image.hpp:32:1: error: using declarations in the global namespace in headers are prohibited [google-global-names-in-headers,-warnings-as-errors]
using std::vector;
^
```

Reasonable enough: `#include` just includes source code of one file to another,
so global `using` will add some entities to another files implicitly,
and removal or changing of order of some included files
will lead to strange errors.

Avoid implicit conversion to 'bool'
===================================

Another one fail in build
https://travis-ci.org/char-lie/stereo-parallel/jobs/449513554

```
/home/travis/build/char-lie/stereo-parallel/include/image.cpp:28:10: error: implicit cast 'ULONG' (aka 'unsigned long') -> bool [readability-implicit-bool-cast,-warnings-as-errors]
    if (!image.max_value || !image.width || !image.height)
        ~^~~~~
        (                == 0u)
/home/travis/build/char-lie/stereo-parallel/include/image.cpp:28:30: error: implicit cast 'ULONG' (aka 'unsigned long') -> bool [readability-implicit-bool-cast,-warnings-as-errors]
    if (!image.max_value || !image.width || !image.height)
                            ~^~~~~
                            (            == 0u)
/home/travis/build/char-lie/stereo-parallel/include/image.cpp:28:46: error: implicit cast 'ULONG' (aka 'unsigned long') -> bool [readability-implicit-bool-cast,-warnings-as-errors]
    if (!image.max_value || !image.width || !image.height)
                                            ~^~~~~       ~
                                            (             == 0u)
```

It's said that implicit conversion to `bool` may lead to bugs.
Okay, let's be explicit
https://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-conversion.html

Treat cppcoreguidelines-pro-type-vararg as warning
==================================================

An error occurred
https://travis-ci.org/char-lie/stereo-parallel/jobs/449517928

```
/home/travis/build/char-lie/stereo-parallel/tests/image.cpp:37:5: error: do not call c-style vararg functions [cppcoreguidelines-pro-type-vararg,-warnings-as-errors]
    BOOST_CHECK(image.data == vector<ULONG>({0, 1}));
    ^
/usr/include/boost/test/test_tools.hpp:110:45: note: expanded from macro 'BOOST_CHECK'
#define BOOST_CHECK( P )                    BOOST_CHECK_IMPL( (P), BOOST_TEST_STRINGIZE( P ), CHECK, CHECK_PRED )
                                            ^
/usr/include/boost/test/test_tools.hpp:91:5: note: expanded from macro 'BOOST_CHECK_IMPL'
    BOOST_TEST_TOOL_IMPL( check_impl, P, check_descr, TL, CT ), 0 );\
    ^
/usr/include/boost/test/test_tools.hpp:77:5: note: expanded from macro 'BOOST_TEST_TOOL_IMPL'
    ::boost::test_tools::tt_detail::func(                               \
    ^
```

I will not avoid usage of `BOOST_CHECK`,
so I'll treat the error as a warning.