### PR TITLE
Close #15: Implement PGM format reader and writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,33 +100,11 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.7
           packages:
             - clang-3.7
       env:
         - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-      env:
-        - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
-
 
 before_install:
     - eval "${MATRIX_EVAL}"

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -20,7 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 add_library(image image.cpp)
+add_library(pgm_io pgm_io.cpp)
 target_include_directories(
     image PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_include_directories(
+    pgm_io PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -1,0 +1,140 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "pgm_io.hpp"
+
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+
+PGM_IO::PGM_IO(std::shared_ptr<struct Image> image) : image{std::move(image)}
+{
+}
+
+void PGM_IO::set_image(const std::shared_ptr<struct Image>& image)
+{
+    this->image = image;
+}
+
+std::shared_ptr<struct Image> PGM_IO::get_image() const
+{
+    return this->image;
+}
+
+std::string PGM_IO::PGM_IO::read_ppm_instruction(std::istream& in)
+{
+    if (in.eof())
+    {
+        in.setstate(std::ios_base::failbit);
+        return "";
+    }
+    std::string current_input;
+    in >> current_input;
+    while (!in.eof() && current_input == "#")
+    {
+        in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        if (in.eof())
+        {
+            in.setstate(std::ios_base::failbit);
+            return "";
+        }
+        in >> current_input;
+    }
+    return current_input;
+}
+
+std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io)
+{
+    if (!ppm_io.get_image() || !image_valid(*ppm_io.get_image()))
+    {
+        return out;
+    }
+    std::shared_ptr<struct Image> image = ppm_io.get_image();
+    out << PGM_IO::FORMAT_CODE << std::endl;
+    out << image->width << " " << image->height << std::endl;
+    out << image->max_value << std::endl;
+    unsigned row_space_consumed = 1;
+    for (unsigned row = 0; row < image->height; ++row)
+    {
+        for (unsigned column = 0; column < image->width; ++column)
+        {
+            out << image->data[get_pixel_index(*image, {row, column})];
+            if (row_space_consumed < PGM_IO::MAX_NUMBERS_PER_ROW)
+            {
+                if (column + 1 < image->width)
+                {
+                    out << " ";
+                }
+                ++row_space_consumed;
+            }
+            else
+            {
+                if (column + 1 < image->width)
+                {
+                    out << std::endl;
+                }
+                row_space_consumed = 0;
+            }
+        }
+        out << std::endl;
+    }
+    return out;
+}
+
+std::istream& operator>>(std::istream& in, PGM_IO& ppm_io)
+{
+    std::string format_code = PGM_IO::read_ppm_instruction(in);
+    if (format_code != PGM_IO::FORMAT_CODE)
+    {
+        in.setstate(std::ios_base::failbit);
+        return in;
+    }
+
+    std::shared_ptr<struct Image> image =
+        std::make_shared<struct Image>(Image{0, 0, 0, {}});
+
+    image->width = std::stoul(PGM_IO::read_ppm_instruction(in));
+    image->height = std::stoul(PGM_IO::read_ppm_instruction(in));
+    image->max_value = std::stoul(PGM_IO::read_ppm_instruction(in));
+    if (image->max_value > PGM_IO::MAX_VALUE_LIMIT)
+    {
+        in.setstate(std::ios_base::failbit);
+        return in;
+    }
+    image->data.resize(image->width * image->height);
+
+    for (unsigned row = 0; row < image->height; ++row)
+    {
+        for (unsigned column = 0; column < image->width; ++column)
+        {
+            image->data[get_pixel_index(*image, {row, column})] =
+                std::stoul(PGM_IO::read_ppm_instruction(in));
+        }
+    }
+
+    ppm_io.set_image(image);
+
+    return in;
+}

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<struct Image> PGM_IO::get_image() const
     return this->image;
 }
 
-std::string PGM_IO::PGM_IO::read_ppm_instruction(std::istream& in)
+std::string PGM_IO::read_pgm_instruction(std::istream& in)
 {
     if (in.eof())
     {

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -123,7 +123,7 @@ std::istream& operator>>(std::istream& in, PGM_IO& ppm_io)
         image->height = std::stoul(PGM_IO::read_pgm_instruction(in));
         image->max_value = std::stoul(PGM_IO::read_pgm_instruction(in));
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         in.setstate(std::ios_base::failbit);
         return in;
@@ -145,7 +145,7 @@ std::istream& operator>>(std::istream& in, PGM_IO& ppm_io)
                 image->data[get_pixel_index(*image, {row, column})] =
                     std::stoul(PGM_IO::read_pgm_instruction(in));
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 in.setstate(std::ios_base::failbit);
                 return in;

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -60,6 +60,10 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
         }
         in >> current_input;
     }
+    if (current_input == "#")
+    {
+        return "";
+    }
     return current_input;
 }
 

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -47,7 +47,6 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
 {
     if (in.eof())
     {
-        in.setstate(std::ios_base::failbit);
         return "";
     }
     std::string current_input;
@@ -57,7 +56,6 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
         in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         if (in.eof())
         {
-            in.setstate(std::ios_base::failbit);
             return "";
         }
         in >> current_input;

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -155,7 +155,7 @@ std::istream& operator>>(std::istream& in, PGM_IO& ppm_io)
 
     if (!in.eof())
     {
-        if (PGM_IO::read_pgm_instruction(in) != "")
+        if (!PGM_IO::read_pgm_instruction(in).empty())
         {
             in.setstate(std::ios_base::failbit);
             return in;

--- a/include/pgm_io.hpp
+++ b/include/pgm_io.hpp
@@ -29,28 +29,125 @@
 
 #include <image.hpp>
 
+/**
+ * \brief Input and output operations for PGM image format.
+ *
+ * The class allows to read and write ::Image
+ * from stream that contains image in
+ * <a href="http://netpbm.sourceforge.net/doc/pgm.html">"plain" PGM</a>
+ * and write it to stream in this format.
+ *
+ * The structure is very simple.
+ * All chunks of information are separated by whitespace
+ * (space, tab or new line).
+ * Let's call one chunk an \b instruction.
+ * All instructions except comments and the first instruction
+ * are regular ASCII numbers.
+ * Comments start with `#` character
+ * and go to the end of the line where the symbol occurs.
+ * PGM file contains the following instructions in the following order:
+ *
+ * - Two magic characters: `P2`;
+ * - Two numbers:
+ *   width (number of columns) and height (number of rows);
+ * - Maximum gray value;
+ * - List of intensities in row-major order.
+ */
 class PGM_IO
 {
 private:
+    /**
+     * \brief Pointer to an ::Image the ::PGM_IO had read or needs to write.
+     */
     std::shared_ptr<struct Image> image;
     static std::string read_ppm_instruction(std::istream& in);
 public:
+    /**
+     * \brief Maximum value of maximum gray value.
+     */
     static const unsigned MAX_VALUE_LIMIT = 1u << 16u;
+    /**
+     * \brief Maximal number of decimal digits in intensity integer.
+     *
+     * Exact formula is
+     *
+     * \f[
+     *  MAX\_COLOR\_DIGITS =
+     *  \left\lceil \log_{10}{MAX\_VALUE\_LIMIT} \right\rceil
+     * \f]
+     *
+     * Though, `log10` function seems not to have `constexpr` overload,
+     * so it's needed to hardcode the constant.
+     */
     static const unsigned MAX_COLOR_DIGITS = 5;
+    /**
+     * \brief Maximal number of symbols per line.
+     *
+     * In description of the plain PGM format
+     * it's said that no line should be longer than `70` characters.
+     */
     static const unsigned MAX_COLUMNS = 70;
+    /**
+     * \brief Maximal number of instructions per line.
+     *
+     * It's easier to limit number of instruction per line
+     * using the longest possible size,
+     * than calculate length of each instruction in runtime.
+     */
     static const unsigned MAX_NUMBERS_PER_ROW =
         MAX_COLUMNS / (1 + MAX_COLOR_DIGITS);
+    /**
+     * \brief Magic string that identifies the plain PGM format.
+     */
     static constexpr const char* FORMAT_CODE = "P2";
+    /**
+     * \brief Default constructor.
+     */
     PGM_IO() = default;
+    /**
+     * \brief Default copy constructor just makes a shallow copy.
+     */
     PGM_IO(const PGM_IO&) = default;
+    /**
+     * \brief Default move constructor.
+     */
     PGM_IO(PGM_IO&&) = default;
+    /**
+     * \brief Default copy assignment operator.
+     */
     PGM_IO& operator=(const PGM_IO&) = default;
+    /**
+     * \brief Default move assignment operator.
+     */
     PGM_IO& operator=(PGM_IO&&) = default;
+    /**
+     * \brief Constructor with specific image.
+     *
+     * If we want to write a file,
+     * we may want to create a ::PGM_IO instance
+     * with ::Image specified immediately.
+     */
     explicit PGM_IO(std::shared_ptr<struct Image> image);
+    /**
+     * \brief Default destructor.
+     */
     ~PGM_IO() = default;
+    /**
+     * \brief Image setter.
+     */
     void set_image(const std::shared_ptr<struct Image>& image);
+    /**
+     * \brief Image getter.
+     */
     std::shared_ptr<struct Image> get_image() const;
-
+    /**
+     * \brief Overload of `>>` operator to read an image from input stream.
+     *
+     * Sets
+     * <a href="https://en.cppreference.com/w/cpp/io/ios_base/iostate">
+     * failbit</a>
+     * in the case of wrong file format (including blank file).
+     */
     friend std::istream& operator>>(std::istream& in, PGM_IO& ppm_io);
 };
 

--- a/include/pgm_io.hpp
+++ b/include/pgm_io.hpp
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef PGM_IO_HPP
+#define PGM_IO_HPP
+
+#include <memory>
+#include <string>
+
+#include <image.hpp>
+
+class PGM_IO
+{
+private:
+    std::shared_ptr<struct Image> image;
+    static std::string read_ppm_instruction(std::istream& in);
+public:
+    static const unsigned MAX_VALUE_LIMIT = 1u << 16u;
+    static const unsigned MAX_COLOR_DIGITS = 5;
+    static const unsigned MAX_COLUMNS = 70;
+    static const unsigned MAX_NUMBERS_PER_ROW =
+        MAX_COLUMNS / (1 + MAX_COLOR_DIGITS);
+    static constexpr const char* FORMAT_CODE = "P2";
+    PGM_IO() = default;
+    PGM_IO(const PGM_IO&) = default;
+    PGM_IO(PGM_IO&&) = default;
+    PGM_IO& operator=(const PGM_IO&) = default;
+    PGM_IO& operator=(PGM_IO&&) = default;
+    explicit PGM_IO(std::shared_ptr<struct Image> image);
+    ~PGM_IO() = default;
+    void set_image(const std::shared_ptr<struct Image>& image);
+    std::shared_ptr<struct Image> get_image() const;
+
+    friend std::istream& operator>>(std::istream& in, PGM_IO& ppm_io);
+};
+
+std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io);
+
+#endif

--- a/include/pgm_io.hpp
+++ b/include/pgm_io.hpp
@@ -155,8 +155,10 @@ public:
      * in the case of wrong file format (including blank file).
      */
     friend std::istream& operator>>(std::istream& in, PGM_IO& ppm_io);
+    /**
+     * \brief Overload of `<<` operator to write an image to output stream.
+     */
+    friend std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io);
 };
-
-std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io);
 
 #endif

--- a/include/pgm_io.hpp
+++ b/include/pgm_io.hpp
@@ -60,7 +60,13 @@ private:
      * \brief Pointer to an ::Image the ::PGM_IO had read or needs to write.
      */
     std::shared_ptr<struct Image> image;
-    static std::string read_ppm_instruction(std::istream& in);
+    /**
+     * \brief Read the next chunk ignoring comments.
+     *
+     * \return String with instruction,
+     * or blank string if input stream is finished.
+     */
+    static std::string read_pgm_instruction(std::istream& in);
 public:
     /**
      * \brief Maximum value of maximum gray value.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,11 +21,12 @@
 # SOFTWARE.
 find_package(Boost 1.54 REQUIRED COMPONENTS unit_test_framework)
 
-add_executable(test_executable api.cpp image.cpp)
+add_executable(test_executable api.cpp image.cpp pgm_io.cpp)
 target_include_directories(test_executable PRIVATE ${BOOST_INCLUDE_DIRS})
 target_link_libraries(
     test_executable
     image
+    pgm_io
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
 )
 target_compile_definitions(

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -24,8 +24,6 @@
 #include <boost/test/unit_test.hpp>
 #include <image.hpp>
 
-using std::vector;
-
 BOOST_AUTO_TEST_SUITE(ImageTest)
 
 BOOST_AUTO_TEST_CASE(create_image)
@@ -34,7 +32,7 @@ BOOST_AUTO_TEST_CASE(create_image)
     BOOST_CHECK_EQUAL(image.width, 2);
     BOOST_CHECK_EQUAL(image.height, 1);
     BOOST_CHECK_EQUAL(image.max_value, 1);
-    BOOST_CHECK(image.data == vector<ULONG>({0, 1}));
+    BOOST_CHECK(image.data == std::vector<ULONG>({0, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(check_image_valid)

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -61,22 +61,30 @@ BOOST_AUTO_TEST_CASE(image_invalid_size)
 
 BOOST_AUTO_TEST_CASE(check_get_pixel_index)
 {
-    struct Image image{2, 2, 3, {3, 2, 1, 0}};
+    struct Image image{3, 2, 5, {5, 4, 3, 2, 1, 0}};
     BOOST_CHECK(image_valid(image));
-    BOOST_CHECK(get_pixel_index(image, {0, 0}) == 0);
-    BOOST_CHECK(get_pixel_index(image, {0, 1}) == 1);
-    BOOST_CHECK(get_pixel_index(image, {1, 0}) == 2);
-    BOOST_CHECK(get_pixel_index(image, {1, 1}) == 3);
+    BOOST_CHECK_EQUAL(image.width, 3);
+    BOOST_CHECK_EQUAL(image.height, 2);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {0, 0}), 0);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {0, 1}), 1);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {0, 2}), 2);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {1, 0}), 3);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {1, 1}), 4);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {1, 2}), 5);
 }
 
 BOOST_AUTO_TEST_CASE(check_get_pixel_value)
 {
-    struct Image image{2, 2, 3, {3, 2, 1, 0}};
+    struct Image image{3, 2, 5, {5, 4, 3, 2, 1, 0}};
     BOOST_CHECK(image_valid(image));
-    BOOST_CHECK(get_pixel_value(image, {0, 0}) == 3);
-    BOOST_CHECK(get_pixel_value(image, {0, 1}) == 2);
-    BOOST_CHECK(get_pixel_value(image, {1, 0}) == 1);
-    BOOST_CHECK(get_pixel_value(image, {1, 1}) == 0);
+    BOOST_CHECK_EQUAL(image.width, 3);
+    BOOST_CHECK_EQUAL(image.height, 2);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 0}), 5);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 1}), 4);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 2}), 3);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 0}), 2);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 1}), 1);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 2}), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(read_write_image)
 3 4 5
 )image"};
 
-    std::istringstream image_input{image_string.c_str()};
+    std::istringstream image_input{image_string};
     image_input >> pgm_io;
     BOOST_CHECK(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(read_write_imagelong)
 0
 )image"};
 
-    std::istringstream image_input{image_string.c_str()};
+    std::istringstream image_input{image_string};
     image_input >> pgm_io;
     BOOST_CHECK(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 12);

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -23,13 +23,13 @@
  */
 #include <boost/test/unit_test.hpp>
 
-#include <string>
-#include <sstream>
 #include <iostream>
 #include <memory>
+#include <sstream>
+#include <string>
 
-#include <pgm_io.hpp>
 #include <image.hpp>
+#include <pgm_io.hpp>
 
 BOOST_AUTO_TEST_SUITE(PGM_IO_test)
 

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -1,0 +1,187 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <strstream>
+#include <iostream>
+#include <memory>
+
+#include <pgm_io.hpp>
+#include <image.hpp>
+
+BOOST_AUTO_TEST_SUITE(PGM_IO_test)
+
+BOOST_AUTO_TEST_CASE(read_image)
+{
+    PGM_IO pgm_io;
+    std::istrstream image_content{R"image(
+    # Grayscale image
+    P2
+    # 3 columns and 2 rows
+    3 2
+    10 # Another pretty comment before a blank line
+
+    0 1 2
+    3 4 5
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(pgm_io.get_image());
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 2);
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 10);
+
+    struct Image image{*pgm_io.get_image()};
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 0}), 0);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 1}), 1);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 2}), 2);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 0}), 3);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 1}), 4);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 2}), 5);
+}
+
+BOOST_AUTO_TEST_CASE(read_wrong_format_name)
+{
+    PGM_IO pgm_io;
+    std::istrstream image_content{R"image(
+    P
+    3 2
+    10
+    0 1 2
+    3 4 5
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
+}
+
+BOOST_AUTO_TEST_CASE(read_wrong_max_value)
+{
+    PGM_IO pgm_io;
+    std::istrstream image_content{R"image(
+    P2
+    3 2
+    65537
+    0 1 2
+    3 4 5
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
+}
+
+BOOST_AUTO_TEST_CASE(read_wrong_data)
+{
+    PGM_IO pgm_io;
+    std::istrstream image_content{R"image(
+    P2
+    3 2
+    -1
+    0 1 2
+    3 4
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
+}
+
+BOOST_AUTO_TEST_CASE(write_image)
+{
+    std::shared_ptr<struct Image> image = std::make_shared<struct Image>(
+        Image{3, 2, 5, {0, 1, 2, 3, 4, 5}});
+    PGM_IO pgm_io{image};
+
+    std::ostrstream image_content;
+    image_content << pgm_io << std::ends;
+
+    BOOST_CHECK_EQUAL(image_content.str(),
+R"image(P2
+3 2
+5
+0 1 2
+3 4 5
+)image");
+}
+
+BOOST_AUTO_TEST_CASE(write_no_image)
+{
+    PGM_IO pgm_io;
+
+    std::ostrstream image_content;
+    image_content << pgm_io << std::ends;
+
+    BOOST_CHECK_EQUAL(image_content.str(), "");
+}
+
+BOOST_AUTO_TEST_CASE(read_write_image)
+{
+    PGM_IO pgm_io;
+    std::string image_string{R"image(P2
+3 2
+5
+0 1 2
+3 4 5
+)image"};
+
+    std::istrstream image_input{image_string.c_str()};
+    image_input >> pgm_io;
+    BOOST_CHECK(pgm_io.get_image());
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 2);
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 5);
+
+    std::ostrstream image_output;
+    image_output << pgm_io << std::ends;
+
+    BOOST_CHECK_EQUAL(image_output.str(), image_string);
+}
+
+BOOST_AUTO_TEST_CASE(read_write_imagelong)
+{
+    PGM_IO pgm_io;
+    std::string image_string{R"image(P2
+12 3
+65536
+65536 65536 65536 65536 65536 65536 65536 65536 65536 65536 65536
+65536
+1 2 3 4 5 6 7 8 9 10 11
+12
+0 1 100 1000 10000 5 50 500 5000 50000 65535
+0
+)image"};
+
+    std::istrstream image_input{image_string.c_str()};
+    image_input >> pgm_io;
+    BOOST_CHECK(pgm_io.get_image());
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 12);
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 3);
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 65536);
+
+    std::ostrstream image_output;
+    image_output << pgm_io << std::ends;
+
+    BOOST_CHECK_EQUAL(image_output.str(), image_string);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -24,7 +24,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <string>
-#include <strstream>
+#include <sstream>
 #include <iostream>
 #include <memory>
 
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_SUITE(PGM_IO_test)
 BOOST_AUTO_TEST_CASE(read_image)
 {
     PGM_IO pgm_io;
-    std::istrstream image_content{R"image(
+    std::istringstream image_content{R"image(
     # Grayscale image
     P2
     # 3 columns and 2 rows
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(read_image)
 BOOST_AUTO_TEST_CASE(read_wrong_format_name)
 {
     PGM_IO pgm_io;
-    std::istrstream image_content{R"image(
+    std::istringstream image_content{R"image(
     P
     3 2
     10
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(read_wrong_format_name)
 BOOST_AUTO_TEST_CASE(read_wrong_max_value)
 {
     PGM_IO pgm_io;
-    std::istrstream image_content{R"image(
+    std::istringstream image_content{R"image(
     P2
     3 2
     65537
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(read_wrong_max_value)
 BOOST_AUTO_TEST_CASE(read_wrong_data)
 {
     PGM_IO pgm_io;
-    std::istrstream image_content{R"image(
+    std::istringstream image_content{R"image(
     P2
     3 2
     -1
@@ -112,8 +112,8 @@ BOOST_AUTO_TEST_CASE(write_image)
         Image{3, 2, 5, {0, 1, 2, 3, 4, 5}});
     PGM_IO pgm_io{image};
 
-    std::ostrstream image_content;
-    image_content << pgm_io << std::ends;
+    std::ostringstream image_content;
+    image_content << pgm_io;
 
     BOOST_CHECK_EQUAL(image_content.str(),
 R"image(P2
@@ -128,8 +128,8 @@ BOOST_AUTO_TEST_CASE(write_no_image)
 {
     PGM_IO pgm_io;
 
-    std::ostrstream image_content;
-    image_content << pgm_io << std::ends;
+    std::ostringstream image_content;
+    image_content << pgm_io;
 
     BOOST_CHECK_EQUAL(image_content.str(), "");
 }
@@ -144,15 +144,15 @@ BOOST_AUTO_TEST_CASE(read_write_image)
 3 4 5
 )image"};
 
-    std::istrstream image_input{image_string.c_str()};
+    std::istringstream image_input{image_string.c_str()};
     image_input >> pgm_io;
     BOOST_CHECK(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 2);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 5);
 
-    std::ostrstream image_output;
-    image_output << pgm_io << std::ends;
+    std::ostringstream image_output;
+    image_output << pgm_io;
 
     BOOST_CHECK_EQUAL(image_output.str(), image_string);
 }
@@ -171,15 +171,15 @@ BOOST_AUTO_TEST_CASE(read_write_imagelong)
 0
 )image"};
 
-    std::istrstream image_input{image_string.c_str()};
+    std::istringstream image_input{image_string.c_str()};
     image_input >> pgm_io;
     BOOST_CHECK(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 12);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 65536);
 
-    std::ostrstream image_output;
-    image_output << pgm_io << std::ends;
+    std::ostringstream image_output;
+    image_output << pgm_io;
 
     BOOST_CHECK_EQUAL(image_output.str(), image_string);
 }

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(read_image)
     3 4 5
     )image"};
     image_content >> pgm_io;
-    BOOST_CHECK(pgm_io.get_image());
+    BOOST_REQUIRE(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 2);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 10);
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(read_write_image)
 
     std::istringstream image_input{image_string};
     image_input >> pgm_io;
-    BOOST_CHECK(pgm_io.get_image());
+    BOOST_REQUIRE(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 2);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 5);
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(read_write_imagelong)
 
     std::istringstream image_input{image_string};
     image_input >> pgm_io;
-    BOOST_CHECK(pgm_io.get_image());
+    BOOST_REQUIRE(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 12);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 65536);

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -45,6 +45,8 @@ BOOST_AUTO_TEST_CASE(read_image)
 
     0 1 2
     3 4 5
+    # The end
+    # Long end
     )image"};
     image_content >> pgm_io;
     BOOST_REQUIRE(pgm_io.get_image());
@@ -59,6 +61,26 @@ BOOST_AUTO_TEST_CASE(read_image)
     BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 0}), 3);
     BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 1}), 4);
     BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 2}), 5);
+}
+
+BOOST_AUTO_TEST_CASE(read_blank_file)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{""};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
+}
+
+BOOST_AUTO_TEST_CASE(read_comment_file)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    # Comment
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
 }
 
 BOOST_AUTO_TEST_CASE(read_wrong_format_name)
@@ -76,7 +98,7 @@ BOOST_AUTO_TEST_CASE(read_wrong_format_name)
     BOOST_CHECK(!image_content);
 }
 
-BOOST_AUTO_TEST_CASE(read_wrong_max_value)
+BOOST_AUTO_TEST_CASE(read_big_max_value)
 {
     PGM_IO pgm_io;
     std::istringstream image_content{R"image(
@@ -91,7 +113,37 @@ BOOST_AUTO_TEST_CASE(read_wrong_max_value)
     BOOST_CHECK(!image_content);
 }
 
-BOOST_AUTO_TEST_CASE(read_wrong_data)
+BOOST_AUTO_TEST_CASE(read_incomplete_data)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    65537
+    0 1 2
+    3 4
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
+}
+
+BOOST_AUTO_TEST_CASE(read_redundant_data)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    65537
+    0 1 2
+    3 4 5 6
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
+}
+
+BOOST_AUTO_TEST_CASE(read_wrong_max_value)
 {
     PGM_IO pgm_io;
     std::istringstream image_content{R"image(
@@ -99,7 +151,22 @@ BOOST_AUTO_TEST_CASE(read_wrong_data)
     3 2
     -1
     0 1 2
-    3 4
+    3 4 5
+    )image"};
+    image_content >> pgm_io;
+    BOOST_CHECK(!pgm_io.get_image());
+    BOOST_CHECK(!image_content);
+}
+
+BOOST_AUTO_TEST_CASE(read_intensity_letter)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    5
+    p 1 2
+    3 4 5
     )image"};
     image_content >> pgm_io;
     BOOST_CHECK(!pgm_io.get_image());


### PR DESCRIPTION
Preface
========

I'm really tired (physically), so this commit (and some another commits) will not contain a lot of _blog-like_ entries,
but it still has useful information.
Also, you can read documentation to `PGM_IO` class to know more.
I want to implement parallel algorithm for stereo vision faster,
but I want the repository to look very good as well.
I even forgot to populate contributing guide with used code style.
I've just created the issue https://github.com/char-lie/stereo-parallel/issues/46.

Use `3x2` image in tests instead of `2x2`
=========================================

It's a good idea to use image with different width and height,
because pixels fetch depends on these numbers
and it would be hard to find errors connected with replaced width and
height in the functions if test images were square.

Implement PGM format reader
===========================

Plain PGM image format was chosen,
because it's simple and represents grayscale images
with configurable maximal intensity.
This allows to store disparity map
with values that overflow `255`
http://netpbm.sourceforge.net/doc/pgm.html

Overloaded `<<` and `>>` operators allow us to read and write images
easily in usual way.
Only `operator>>` needs to be a `friend` of the `PGM_IO` class,
because it uses `read_ppm_instruction` class member
that was decided to be private.
Though, further `operator<<` was made a friend of the `PGM_IO` too.
This allows to have a normal documentation for the operator
without adding `@file` comment.
Also this looks more normal and consistent with `operator>>`.

Use `constexpr` keyword for constant string
===========================================

It's not a good idea to use `std::string` for a static constant string,
because you can't know for sure when it will be destroyed.
If I use a constant `char` pointer, I should use `constexpr`
in order to have an ability to make this member `static`
https://stackoverflow.com/a/9657064/1305036

Otherwise, an error occurs

```
.../stereo-parallel/include/pgm_io.hpp:42:24: error: non-const static data member must be initialized out of line [clang-diagnostic-error]
    static const char* FORMAT_CODE = "P2";
                       ^
```

Pass by value and use `std::move` instead of const reference to pointer
=======================================================================

It's a habit -- to use a constant reference to a variable
that doesn't need to be copied.
Clang Tidy proposed me to pass a value of a pointer instead,
but use `std::move` to move its value
and let a compiler to decide how to optimize this assignment
https://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html

Here is how it told me to do so

```
.../stereo-parallel/include/pgm_io.hpp:47:21: error: pass by value and use std::move [modernize-pass-by-value,-warnings-as-errors]
    explicit PGM_IO(std::shared_ptr<struct Image> image): image{image}
                    ^                                           ~~~~~~
                                                                std::move()
.../stereo-parallel/include/pgm_io.hpp:47:65: error: parameter 'image' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param,-warnings-as-errors]
    explicit PGM_IO(std::shared_ptr<struct Image> image): image{image}
                                                                ^~~~~~
                                                                std::move()
```

Implement special member functions for PGM_IO
=============================================

Clang Tidy wanted me to implement several special member functions.
Okay, let it be to avoid this error

```
.../stereo-parallel/include/pgm_io.hpp:32:7: error: class 'PGM_IO' defines a default destructor, a copy constructor and a move constructor but does not define a copy assignment operator or a move assignment operator [hicpp-special-member-functions,-warnings-as-errors]
class PGM_IO
      ^
```

Use `std::make_shared` instead of `std::shared_ptr` cast from pure pointer
==========================================================================

I really didn't know how to avoid an old `new` operator
when creating a shared pointer to a new object.
Clang Tidy has shown me the right way to do this:
just call `std::make_shared` and pass the object there
https://clang.llvm.org/extra/clang-tidy/checks/modernize-make-shared.html

When I use `new` and `std::shared_ptr` constructor, the error occurres

```
.../stereo-parallel/include/pgm_io.cpp:112:9: error: use std::make_shared instead [modernize-make-shared,-warnings-as-errors]
        std::shared_ptr<struct Image>(new Image{0, 0, 0, {}});
        ^~~~~~~~~~~~~~~~              ~~~~~~~~~
        std::make_shared
```

Use magic number instead of non-constexpr functions for static constant
=======================================================================

`ceil` and `log10` functions have no `constexpr` overloads,
so I just use a magic number to avoid the error

```
.../stereo-parallel/include/pgm_io.hpp:89:37: error: constexpr variable 'MAX_COLOR_DIGITS' must be initialized by a constant expression
    static constexpr const unsigned MAX_COLOR_DIGITS = ceil(log10(MAX_VALUE_LIMIT));      
                                    ^                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../stereo-parallel/include/pgm_io.hpp:89:56: note: non-constexpr function 'ceil' cannot be used in a constant expression
    static constexpr const unsigned MAX_COLOR_DIGITS = ceil(log10(MAX_VALUE_LIMIT));
```


Use `std::sstream` instead of `std::strstream`
==============================================

When I used `std::strstream` there was a problem:
it had a garbage after end of the input,
so I had to use `std::ends` to end the string explicitly
https://openwatcom.users.c-cpp.narkive.com/7tzBBM6z/problem-woth-ostrstream#post4

It appeared that this library is deprecated
https://travis-ci.org/char-lie/stereo-parallel/jobs/450992702

and I've got an error

```
In file included from /home/travis/build/char-lie/stereo-parallel/tests/pgm_io.cpp:27:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/backward/strstream:51:
/usr/bin/../lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/backward/backward_warning.h:32:2: error:
      This file includes at least one deprecated or antiquated header which may
      be removed without further notice at a future date. Please use a
      non-deprecated interface with equivalent functionality instead. For a
      listing of replacement headers and interfaces, consult the file
      backward_warning.h. To disable this warning use -Wno-deprecated.
      [-Werror,-W#warnings]
 ^
```

I should use `sstream` library instead.
It contains `ostringstream` class that doesn't need `std::ends` to end
the string.
https://stackoverflow.com/a/2820289/1305036

Remove redundant conversion to C-style string
=============================================

When `ostrstream` was used,
it was needed to convert string to C-style string of type `char*`.
`ostringstream` can be constructed directly from `string`.
The old code produced the error
https://travis-ci.org/char-lie/stereo-parallel/jobs/451014544

```
/home/travis/build/char-lie/stereo-parallel/tests/pgm_io.cpp:147:36: error: redundant call to 'c_str' [readability-redundant-string-cstr,-warnings-as-errors]
    std::istringstream image_input{image_string.c_str()};
                                   ^~~~~~~~~~~~~~~~~~~~~
                                   image_string
```

Mark pointer check as required
==============================

If we have a null pointer instead of an image pointer,
tests that check properties of the image will fail
while trying to dereference null pointer.
It's better to end the test if image pointer check fails.

Set `failbit` when `std::invalid_argument` thrown
=================================================

I guess, it's better to set a fail bit rather than throw an exception
on wrong input file format.

Catch error by reference
========================

Errors occurred
https://travis-ci.org/char-lie/stereo-parallel/jobs/452082015

```
/home/travis/build/char-lie/stereo-parallel/include/pgm_io.cpp:126:12: error: catch handler catches by value; should catch by reference instead [cert-err09-cpp,-warnings-as-errors]
    catch (std::invalid_argument)
           ^
/home/travis/build/char-lie/stereo-parallel/include/pgm_io.cpp:148:20: error: catch handler catches by value; should catch by reference instead [cert-err09-cpp,-warnings-as-errors]
            catch (std::invalid_argument)
                   ^
```

It's recommended to catch an error by reference, not by value,
in this case
https://clang.llvm.org/extra/clang-tidy/checks/misc-throw-by-value-catch-by-reference.html

Use `empty()` instead of `== ""`
================================

Build failed with one more error
https://travis-ci.org/char-lie/stereo-parallel/jobs/452082015

```
/home/travis/build/char-lie/stereo-parallel/include/pgm_io.cpp:158:13:
error: the 'empty' method should be used to check for emptiness instead
of comparing to an empty object
[readability-container-size-empty,-warnings-as-errors]
        if (PGM_IO::read_pgm_instruction(in) != "")
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                !PGM_IO::read_pgm_instruction(in).empty()
```

That's reasonable: if there is a special check for a string emptiness,
it's better to use it.

Remove old versions of compilers from CI
========================================

`g++4.9` and `clang++3.6` fail to compile the code
because it uses implicit copy constructor for `Image`
https://travis-ci.org/char-lie/stereo-parallel/builds/452085934

```
/home/travis/build/char-lie/stereo-parallel/tests/pgm_io.cpp:57:24: error: no
      viable conversion from 'Image' to 'ULONG' (aka 'unsigned long')
    struct Image image{*pgm_io.get_image()};
                       ^~~~~~~~~~~~~~~~~~~
/home/travis/build/char-lie/stereo-parallel/tests/pgm_io.cpp:57:43: error: 
      missing field 'height' initializer [-Werror,-Wmissing-field-initializers]
    struct Image image{*pgm_io.get_image()};
                                          ^
```

The issue was discussed on bugtracker of GCC
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36750
as well as on CLang forum
http://clang-developers.42468.n3.nabble.com/Wmissing-field-initializers-td3761260.html

It was fixed in the next versions of compilers,
so I will simply remove them from CI.
Also, this will shorten time of tests running.