### PR TITLE
Close #16: Initialize main application

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,9 +5,10 @@
     ",
     "WarningsAsErrors": "\
         *,\
-        -clang-diagnostic-unused-command-line-argument,\
         -cert-err58-cpp,\
-        -google-runtime-int,\
+        -cert-err60-cpp,\
+        -clang-diagnostic-unused-command-line-argument,\
         -cppcoreguidelines-pro-type-vararg,\
+        -google-runtime-int,\
     ",
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,7 @@ before_script:
         -v -v -v"
 
 script:
+    - clang-tidy --version
     - mkdir build
     - cd build
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
           packages:
             - llvm-6.0
             - clang-6.0
-            - clang-tools
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
@@ -129,7 +128,6 @@ before_script:
         -v -v -v"
 
 script:
-    - clang-tidy --version
     - mkdir build
     - cd build
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           packages:
             - llvm-6.0
             - clang-6.0
+            - clang-tools
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,9 @@ before_install:
 
 before_script:
     - sudo apt-get update
-    - sudo apt-get install -y libboost-test-dev
+    - sudo apt-get install -y
+        libboost-test-dev
+        libboost-program-options-dev
     - shopt -s expand_aliases
     - alias clang-static-analyzer="scan-build
         --use-cc=`which $CC`

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,14 @@ Here is a bash script for download, build and test
     cmake --build .
     ctest
 
+Using the application
+=====================
+
+After build,
+your ``build/include`` directory should contain
+``stereo_parallel`` executable file.
+Launch it without parameters to see the ``help``.
+
 Documentation
 =============
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -29,3 +29,17 @@ target_include_directories(
     pgm_io PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+find_package(Boost 1.54 REQUIRED COMPONENTS program_options)
+add_executable(stereo_parallel main.cpp)
+target_include_directories(
+    stereo_parallel
+    PRIVATE
+    ${BOOST_INCLUDE_DIRS}
+)
+target_link_libraries(
+    stereo_parallel
+    image
+    pgm_io
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -29,6 +29,10 @@ target_include_directories(
     pgm_io PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+target_link_libraries(
+    pgm_io
+    image
+)
 
 find_package(Boost 1.54 REQUIRED COMPONENTS program_options)
 add_executable(stereo_parallel main.cpp)

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -77,26 +77,21 @@ struct Image read_image(const std::string& image_path)
     std::ifstream image_file(image_path);
     if (!image_file)
     {
-        throw std::invalid_argument(
-            "Unable to open file `" + image_path + "`."
-        );
+        throw std::invalid_argument("Unable to open file.");
     }
 
     PGM_IO pgm_io;
     image_file >> pgm_io;
     if (!image_file)
     {
-        throw std::invalid_argument(
-            std::string("File `" + image_path +
-            "` is not a correct plain PGM image.").c_str()
-        );
+        throw std::invalid_argument("File is not a correct plain PGM image.");
     }
     if (!pgm_io.get_image())
     {
         throw std::logic_error(
-            std::string("Image `" + image_path + "` is valid, "
+            "Image is valid, "
             "but it wasn't read for some reason. "
-            "Please, report the issue to developers.").c_str()
+            "Please, report the issue to developers."
         );
     }
     return *pgm_io.get_image();

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -41,17 +41,13 @@ int main(int argc, char* argv[]) try
                 read_image(vm["right-image"].as<std::string>())
             };
         }
-        catch (std::invalid_argument& e)
+        catch (const std::invalid_argument& e)
         {
             std::cerr << "Invalid argument: " << e.what() << std::endl;
         }
-        catch (std::logic_error& e)
+        catch (const std::logic_error& e)
         {
             std::cerr << "Logic error: " << e.what() << std::endl;
-        }
-        catch (...)
-        {
-            throw;
         }
     }
     else if (vm.count("left-image") > 0 || vm.count("right-image") > 0)
@@ -67,7 +63,7 @@ int main(int argc, char* argv[]) try
     }
     return 0;
 }
-catch(std::exception& e) {
+catch(const std::exception& e) {
     std::cerr << "Unexpected exception: " << e.what() << std::endl;
     return 1;
 }
@@ -91,16 +87,16 @@ struct Image read_image(const std::string& image_path)
     if (!image_file)
     {
         throw std::invalid_argument(
-            "File `" + image_path +
-            "` is not a correct plain PGM image."
+            std::string("File `" + image_path +
+            "` is not a correct plain PGM image.").c_str()
         );
     }
     if (!pgm_io.get_image())
     {
         throw std::logic_error(
-            "Image `" + image_path + "` is valid, "
+            std::string("Image `" + image_path + "` is valid, "
             "but it wasn't read for some reason. "
-            "Please, report the issue to developers."
+            "Please, report the issue to developers.").c_str()
         );
     }
     return *pgm_io.get_image();

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -28,9 +28,9 @@ int main(int argc, char* argv[]) try
         boost::program_options::parse_command_line(argc, argv, desc),
         vm
     );
-    boost::program_options::notify(vm);    
+    boost::program_options::notify(vm);   
 
-    if (vm.count("left-image") && vm.count("right-image"))
+    if (vm.count("left-image") == 1 && vm.count("right-image") == 1)
     {
         struct Image left_image;
         struct Image right_image;
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) try
             std::cerr << "Logic error: " << e.what() << std::endl;
         }
     }
-    else if (vm.count("left-image") || vm.count("right-image"))
+    else if (vm.count("left-image") > 0 || vm.count("right-image") > 0)
     {
         std::cerr
             << "You should specify both left and right image."

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -6,8 +6,8 @@
 #include <stdexcept>
 #include <string>
 
-#include <pgm_io.hpp>
 #include <image.hpp>
+#include <pgm_io.hpp>
 
 struct Image read_image(std::string image_path);
 

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -1,0 +1,100 @@
+#include <boost/program_options.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <pgm_io.hpp>
+#include <image.hpp>
+
+struct Image read_image(std::string image_path);
+
+int main(int argc, char* argv[]) try
+{
+    boost::program_options::options_description desc("Allowed options");
+    desc.add_options()
+        ("help,h", "Help message")
+        ("left-image,l",
+         boost::program_options::value<std::string>(),
+         "Left image")
+        ("right-image,r",
+         boost::program_options::value<std::string>(),
+         "Right image");
+
+    boost::program_options::variables_map vm;
+    boost::program_options::store(
+        boost::program_options::parse_command_line(argc, argv, desc),
+        vm
+    );
+    boost::program_options::notify(vm);    
+
+    if (vm.count("left-image") && vm.count("right-image"))
+    {
+        struct Image left_image;
+        struct Image right_image;
+        try {
+            left_image = read_image(vm["left-image"].as<std::string>());
+            right_image = read_image(vm["right-image"].as<std::string>());
+        }
+        catch (std::invalid_argument& e)
+        {
+            std::cerr << "Invalid argument: " << e.what() << std::endl;
+        }
+        catch (std::logic_error& e)
+        {
+            std::cerr << "Logic error: " << e.what() << std::endl;
+        }
+    }
+    else if (vm.count("left-image") || vm.count("right-image"))
+    {
+        std::cerr
+            << "You should specify both left and right image."
+            << std::endl;
+    }
+    else
+    {
+        std::cout << desc;
+        return 1;
+    }
+    return 0;
+}
+catch(std::exception& e) {
+    std::cerr << "Unexpected exception: " << e.what() << std::endl;
+    return 1;
+}
+catch(...) {
+    std::cerr << "Exception of unknown type!" << std::endl;
+    return 1;
+}
+
+struct Image read_image(std::string image_path)
+{
+    std::ifstream image_file(image_path);
+    if (!image_file)
+    {
+        throw std::invalid_argument(
+            "Unable to open file `" + image_path + "`."
+        );
+    }
+
+    PGM_IO pgm_io;
+    image_file >> pgm_io;
+    if (!image_file)
+    {
+        throw std::invalid_argument(
+            "File `" + image_path +
+            "` is not a correct plain PGM image."
+        );
+    }
+    if (!pgm_io.get_image())
+    {
+        throw std::logic_error(
+            "Image `" + image_path + "` is valid, "
+            "but it wasn't read for some reason. "
+            "Please, report the issue to developers."
+        );
+    }
+    return *pgm_io.get_image();
+}

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -32,7 +32,8 @@ int main(int argc, char* argv[]) try
 
     if (vm.count("left-image") == 1 && vm.count("right-image") == 1)
     {
-        try {
+        try
+        {
             struct Image left_image{
                 read_image(vm["left-image"].as<std::string>())
             };
@@ -47,6 +48,10 @@ int main(int argc, char* argv[]) try
         catch (const std::logic_error& e)
         {
             std::cerr << "Logic error: " << e.what() << std::endl;
+        }
+        catch (...)
+        {
+            throw;
         }
     }
     else if (vm.count("left-image") > 0 || vm.count("right-image") > 0)

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -32,11 +32,13 @@ int main(int argc, char* argv[]) try
 
     if (vm.count("left-image") == 1 && vm.count("right-image") == 1)
     {
-        struct Image left_image;
-        struct Image right_image;
         try {
-            left_image = read_image(vm["left-image"].as<std::string>());
-            right_image = read_image(vm["right-image"].as<std::string>());
+            struct Image left_image{
+                read_image(vm["left-image"].as<std::string>())
+            };
+            struct Image right_image{
+                read_image(vm["right-image"].as<std::string>())
+            };
         }
         catch (std::invalid_argument& e)
         {

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -41,11 +41,11 @@ int main(int argc, char* argv[]) try
                 read_image(vm["right-image"].as<std::string>())
             };
         }
-        catch (const std::invalid_argument& e)
+        catch (std::invalid_argument& e)
         {
             std::cerr << "Invalid argument: " << e.what() << std::endl;
         }
-        catch (const std::logic_error& e)
+        catch (std::logic_error& e)
         {
             std::cerr << "Logic error: " << e.what() << std::endl;
         }
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) try
     }
     return 0;
 }
-catch(const std::exception& e) {
+catch(std::exception& e) {
     std::cerr << "Unexpected exception: " << e.what() << std::endl;
     return 1;
 }

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -40,11 +40,11 @@ int main(int argc, char* argv[]) try
                 read_image(vm["right-image"].as<std::string>())
             };
         }
-        catch (std::invalid_argument& e)
+        catch (const std::invalid_argument& e)
         {
             std::cerr << "Invalid argument: " << e.what() << std::endl;
         }
-        catch (std::logic_error& e)
+        catch (const std::logic_error& e)
         {
             std::cerr << "Logic error: " << e.what() << std::endl;
         }
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) try
     }
     return 0;
 }
-catch(std::exception& e) {
+catch(const std::exception& e) {
     std::cerr << "Unexpected exception: " << e.what() << std::endl;
     return 1;
 }

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -9,7 +9,7 @@
 #include <image.hpp>
 #include <pgm_io.hpp>
 
-struct Image read_image(std::string image_path);
+struct Image read_image(const std::string& image_path);
 
 int main(int argc, char* argv[]) try
 {
@@ -69,7 +69,7 @@ catch(...) {
     return 1;
 }
 
-struct Image read_image(std::string image_path)
+struct Image read_image(const std::string& image_path)
 {
     std::ifstream image_file(image_path);
     if (!image_file)

--- a/include/main.cpp
+++ b/include/main.cpp
@@ -43,11 +43,11 @@ int main(int argc, char* argv[]) try
         }
         catch (const std::invalid_argument& e)
         {
-            std::cerr << "Invalid argument: " << e.what() << std::endl;
+            std::cerr << "Invalid argument: unable to read an image." << std::endl;
         }
         catch (const std::logic_error& e)
         {
-            std::cerr << "Logic error: " << e.what() << std::endl;
+            std::cerr << "Logic error: an image was parsed, but wasn't stored." << std::endl;
         }
     }
     else if (vm.count("left-image") > 0 || vm.count("right-image") > 0)
@@ -77,22 +77,18 @@ struct Image read_image(const std::string& image_path)
     std::ifstream image_file(image_path);
     if (!image_file)
     {
-        throw std::invalid_argument("Unable to open file.");
+        throw std::invalid_argument("");
     }
 
     PGM_IO pgm_io;
     image_file >> pgm_io;
     if (!image_file)
     {
-        throw std::invalid_argument("File is not a correct plain PGM image.");
+        throw std::invalid_argument("");
     }
     if (!pgm_io.get_image())
     {
-        throw std::logic_error(
-            "Image is valid, "
-            "but it wasn't read for some reason. "
-            "Please, report the issue to developers."
-        );
+        throw std::logic_error("");
     }
     return *pgm_io.get_image();
 }


### PR DESCRIPTION
Boost Program Options usage
===========================

Logical way to start using Boost Program Options
is the tutorial
https://www.boost.org/doc/libs/1_68_0/doc/html/program_options/tutorial.html

It looks messy, but all becomes clear with full code example
https://www.boost.org/doc/libs/1_57_0/libs/program_options/example/first.cpp

I didn't find any default tools
to check whether input parameter is an existent file,
so I've made my own
(also checked whether it's a correct plain PGM image file).
In order to check whether all is good we simply use `operator!`,
which is a synonym to `fail()` member function
http://www.cplusplus.com/reference/ios/ios/fail/

Should install `libboost-program-options-dev` to run tests successfully
https://stackoverflow.com/a/20502807/1305036

Exceptions handling
===================

The code example has an ugly `try-catch` block within.
I know a modern approach called `Function-try-block`.
You should not create one more indentation level,
you just write a `try` word after the function signature
and use `catch` after the function block
https://en.cppreference.com/w/cpp/language/function-try-block

I didn't know whether I have to use `\n` or `std::endl`
in error output (`std::cerr` may be a regular file).
Example contains `\n`, but I don't like to use it in modern C++.
My concern was caused by the fact
that Python has a similar thing called `os.linesep`,
and documentation says that I shouldn't use it as line ending in files,
and I should use `\n` instead
https://docs.python.org/3/library/os.html#os.linesep
Though, it seems like C++ has no such limitation
and I can use `std::endl` freely for line endings in files
https://stackoverflow.com/a/213977/1305036

Project configuration
=====================

Add executable
--------------

First, I find `Boost` library using `find_package` command.
Then, I add an executable using `add_executable` command.
The first argument is the executable name (`stereo_parallel`)
and the second one is the source file (`main.cpp`)
https://cmake.org/cmake-tutorial/
After that, I use familiar steps:
specify `target_include_directories` and `target_link_libraries`.
Note that I should link Boost Program Options library
using `Boost_PROGRAM_OPTIONS_LIBRARY` variable
https://stackoverflow.com/q/3897839/1305036

Link dependencies with each other
---------------------------------

The project didn't compile.
I thought that the issue is a linking type
(shared versus static libraries)

Error without shared (with static)
`cmake .. -DBUILD_SHARED_LIBS=OFF && cmake --build .`

```
libpgm_io.a(pgm_io.cpp.o): In function `operator<<(std::ostream&, PGM_IO const&)':
pgm_io.cpp:(.text+0x477): undefined reference to `image_valid(Image const&)'
pgm_io.cpp:(.text+0x615): undefined reference to `get_pixel_index(Image const&, Pixel)'
libpgm_io.a(pgm_io.cpp.o): In function `operator>>(std::istream&, PGM_IO&)':
pgm_io.cpp:(.text+0xa9a): undefined reference to `get_pixel_index(Image const&, Pixel)'
collect2: error: ld returned 1 exit status
include/CMakeFiles/stereo_parallel.dir/build.make:97: recipe for target 'include/stereo_parallel' failed
make[2]: *** [include/stereo_parallel] Error 1
CMakeFiles/Makefile2:90: recipe for target 'include/CMakeFiles/stereo_parallel.dir/all' failed
make[1]: *** [include/CMakeFiles/stereo_parallel.dir/all] Error 2
Makefile:94: recipe for target 'all' failed
make: *** [all] Error 2
```

With shared (instead of static)
`cmake .. -DBUILD_SHARED_LIBS=ON && cmake --build .`

```
libpgm_io.so: undefined reference to `image_valid(Image const&)'
libpgm_io.so: undefined reference to `get_pixel_index(Image const&, Pixel)'
collect2: error: ld returned 1 exit status
include/CMakeFiles/stereo_parallel.dir/build.make:97: recipe for target 'include/stereo_parallel' failed
make[2]: *** [include/stereo_parallel] Error 1
CMakeFiles/Makefile2:90: recipe for target 'include/CMakeFiles/stereo_parallel.dir/all' failed
make[1]: *** [include/CMakeFiles/stereo_parallel.dir/all] Error 2
Makefile:94: recipe for target 'all' failed
make: *** [all] Error 2
```

It's appeared that I should link `image` library to `pgm_io` library,
because the second one didn't see the first one
```
target_link_libraries(
    pgm_io
    image
)
```

Usage
=====

Convert to plain PGM
`convert input -compress none output.pgm`
https://www.imagemagick.org/discourse-server/viewtopic.php?t=18720

Avoid usage of default constructor of `Image`
=============================================

The following error wasn't clear enough for me at first
https://travis-ci.org/char-lie/stereo-parallel/jobs/457129459

```
/home/travis/build/char-lie/stereo-parallel/include/image.hpp:46:8: error: constructor does not initialize these fields: width, height, max_value [cppcoreguidelines-pro-type-member-init,-warnings-as-errors]
struct Image
       ^
```

Documentation didn't clarify a lot.
I've got that it happened because I don't have a constructor,
but it didn't fail before
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-member-init.html

If I don't use default constructor and assign a value immediately,
this works fine.
Let it be a solution at the moment.

Default exceptions are not nothrow copy constructible on Travis CI?
===================================================================

Got strange errors of Clang Tidy
https://travis-ci.org/char-lie/stereo-parallel/jobs/457608756

```
/home/travis/build/char-lie/stereo-parallel/include/main.cpp:80:15: error: thrown exception type is not nothrow copy constructible [cert-err60-cpp,-warnings-as-errors]
        throw std::invalid_argument("");
              ^
/home/travis/build/char-lie/stereo-parallel/include/main.cpp:87:15: error: thrown exception type is not nothrow copy constructible [cert-err60-cpp,-warnings-as-errors]
        throw std::invalid_argument("");
              ^
/home/travis/build/char-lie/stereo-parallel/include/main.cpp:91:15: error: thrown exception type is not nothrow copy constructible [cert-err60-cpp,-warnings-as-errors]
        throw std::logic_error("");
              ^
```

Cannot reproduce it on local machine, only Travis CI.
Documentation of the error
https://clang.llvm.org/extra/clang-tidy/checks/cert-err60-cpp.html
refers us to coding standard of Software Engineering Institute
of Carnegie Mellon University
https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR60-CPP.+Exception+objects+must+be+nothrow+copy+constructible
As long as during exception handling the exception is being copied,
the copy constructor shouldn't throw any exceptions.

`std::logic_error` is inherited from `std::exception`
https://en.cppreference.com/w/cpp/error/logic_error
`std::exception` seems to be marked as `noexcept`
https://en.cppreference.com/w/cpp/error/exception/exception
except the note

> Because copying std::exception is not permitted to throw exceptions,
> when derived classes (such as std::runtime_error)
> have to manage a user-defined diagnostic message,
> it is typically implemented as a copy-on-write string.

At the moment I don't understand what all this mean,
so I'll just treat the error as a warning.
Local downgrade of `clang`, `clang++` and `clang-tidy` to version `5.0`
didn't help to reproduce the issue locally.