### PR TITLE
Fix #48: Incorrect input of images with more than 12 columns and 1 row

### DIFF
--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -77,19 +77,17 @@ std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io)
     out << PGM_IO::FORMAT_CODE << std::endl;
     out << image->width << " " << image->height << std::endl;
     out << image->max_value << std::endl;
-    unsigned row_space_consumed = 1;
     for (unsigned row = 0; row < image->height; ++row)
     {
         for (unsigned column = 0; column < image->width; ++column)
         {
             out << image->data[get_pixel_index(*image, {row, column})];
-            if (row_space_consumed < PGM_IO::MAX_NUMBERS_PER_ROW)
+            if (column == 0 || (column + 1) % PGM_IO::MAX_NUMBERS_PER_ROW != 0)
             {
                 if (column + 1 < image->width)
                 {
                     out << " ";
                 }
-                ++row_space_consumed;
             }
             else
             {
@@ -97,7 +95,6 @@ std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io)
                 {
                     out << std::endl;
                 }
-                row_space_consumed = 0;
             }
         }
         out << std::endl;

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -228,20 +228,20 @@ BOOST_AUTO_TEST_CASE(read_write_imagelong)
 {
     PGM_IO pgm_io;
     std::string image_string{R"image(P2
-12 3
+13 3
 65536
 65536 65536 65536 65536 65536 65536 65536 65536 65536 65536 65536
-65536
+65536 65536
 1 2 3 4 5 6 7 8 9 10 11
-12
+12 13
 0 1 100 1000 10000 5 50 500 5000 50000 65535
-0
+0 2
 )image"};
 
     std::istringstream image_input{image_string};
     image_input >> pgm_io;
     BOOST_REQUIRE(pgm_io.get_image());
-    BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 12);
+    BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 13);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 65536);
 


### PR DESCRIPTION
The fix is a simplification in the same time.
Love such things.
I shouldn't create a separate variable,
I just check whether index of the current column
is divisible by maximal allowed number of columns.
Brilliant.

I should think about dynamic size calculation:
count number of written symbols (for example, using logarithm).
This will prettify output of files with small values and dozen of columns.
Does it make sense?
It will work nice for images with 2-digit numbers with ~23 columns.