### PR TITLE
Fix #49: Check ending of PGM file correctly

### DIFF
--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -23,6 +23,7 @@
  */
 #include "pgm_io.hpp"
 
+#include <cctype>
 #include <ios>
 #include <iostream>
 #include <limits>
@@ -65,6 +66,26 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
         return "";
     }
     return current_input;
+}
+
+bool PGM_IO::check_file_end(std::istream& in)
+{
+    for (char current_input; in && !in.eof(); in.get(current_input))
+    {
+        if (current_input == '#')
+        {
+            in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        }
+        else if (current_input != '\0' && !std::isspace(current_input))
+        {
+            in.setstate(std::ios_base::failbit);
+        };
+    }
+    if (in.eof())
+    {
+        in.clear(std::ios::goodbit | std::ios::eofbit);
+    }
+    return in.good();
 }
 
 std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io)
@@ -150,14 +171,7 @@ std::istream& operator>>(std::istream& in, PGM_IO& ppm_io)
         }
     }
 
-    if (!in.eof())
-    {
-        if (!PGM_IO::read_pgm_instruction(in).empty())
-        {
-            in.setstate(std::ios_base::failbit);
-            return in;
-        }
-    }
+    PGM_IO::check_file_end(in);
 
     ppm_io.set_image(image);
 

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -70,13 +70,15 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
 
 bool PGM_IO::check_file_end(std::istream& in)
 {
-    for (char current_input; in.good() && !in.eof(); in >> current_input)
+    char current_input;
+    while (in.good() && !in.eof())
     {
+        in.get(current_input);
         if (current_input == '#')
         {
             in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         }
-        else if (current_input != '\0' && std::isspace(current_input) != 0)
+        else if (std::isspace(current_input) == 0)
         {
             in.setstate(std::ios_base::failbit);
         };

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -70,13 +70,13 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
 
 bool PGM_IO::check_file_end(std::istream& in)
 {
-    for (char current_input; in && !in.eof(); in.get(current_input))
+    for (char current_input; in.good() && !in.eof(); in >> current_input)
     {
         if (current_input == '#')
         {
             in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         }
-        else if (current_input != '\0' && !std::isspace(current_input))
+        else if (current_input != '\0' && std::isspace(current_input) != 0)
         {
             in.setstate(std::ios_base::failbit);
         };

--- a/include/pgm_io.hpp
+++ b/include/pgm_io.hpp
@@ -67,6 +67,14 @@ private:
      * or blank string if input stream is finished.
      */
     static std::string read_pgm_instruction(std::istream& in);
+    /**
+     * \brief Check whether PGM file ends correctly.
+     *
+     * End of the file should contain only whitespace and comments.
+     * The function checks exactly this fact,
+     * returns `true` if it holds and returns `false` otherwise.
+     */
+    static bool check_file_end(std::istream& in);
 public:
     /**
      * \brief Maximum value of maximum gray value.

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -49,6 +49,7 @@ BOOST_AUTO_TEST_CASE(read_image)
     # Long end
     )image"};
     image_content >> pgm_io;
+    BOOST_CHECK(image_content);
     BOOST_REQUIRE(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 2);
@@ -189,6 +190,7 @@ R"image(P2
 0 1 2
 3 4 5
 )image");
+    BOOST_CHECK(image_content);
 }
 
 BOOST_AUTO_TEST_CASE(write_no_image)
@@ -199,6 +201,7 @@ BOOST_AUTO_TEST_CASE(write_no_image)
     image_content << pgm_io;
 
     BOOST_CHECK_EQUAL(image_content.str(), "");
+    BOOST_CHECK(image_content);
 }
 
 BOOST_AUTO_TEST_CASE(read_write_image)
@@ -213,6 +216,7 @@ BOOST_AUTO_TEST_CASE(read_write_image)
 
     std::istringstream image_input{image_string};
     image_input >> pgm_io;
+    BOOST_CHECK(image_input);
     BOOST_REQUIRE(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 3);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 2);
@@ -222,6 +226,7 @@ BOOST_AUTO_TEST_CASE(read_write_image)
     image_output << pgm_io;
 
     BOOST_CHECK_EQUAL(image_output.str(), image_string);
+    BOOST_CHECK(image_output);
 }
 
 BOOST_AUTO_TEST_CASE(read_write_imagelong)
@@ -240,6 +245,8 @@ BOOST_AUTO_TEST_CASE(read_write_imagelong)
 
     std::istringstream image_input{image_string};
     image_input >> pgm_io;
+
+    BOOST_CHECK(image_input);
     BOOST_REQUIRE(pgm_io.get_image());
     BOOST_CHECK_EQUAL(pgm_io.get_image()->width, 13);
     BOOST_CHECK_EQUAL(pgm_io.get_image()->height, 3);
@@ -249,6 +256,7 @@ BOOST_AUTO_TEST_CASE(read_write_imagelong)
     image_output << pgm_io;
 
     BOOST_CHECK_EQUAL(image_output.str(), image_string);
+    BOOST_CHECK(image_output);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Here I've found a new fact (for me) about C++
https://softwareengineering.stackexchange.com/a/318091

A C++ application cannot tell you
whether the end of a stream has been reached.
Instead, it can try to read something after the end
and set both `failbit` (it fails to read nothing)
and `eof` (the stream finished).
I was wondering about how to distinguish a fail and end of file
(for example, if the last symbol is wrong),
and a simple end of file.
I've come to a conclusion that `in.eof() || in.good()` check is enough.
In the case of file end I should mark the stream as a good one
using `ios::clear` member function that accepts needed flags as a parameter
http://www.cplusplus.com/reference/ios/ios/clear/

I was assured even more when found a note in `istream::get`
documentation.
It says that `failbit` flag is set in the same time
when `EOF` is returned
http://www.cplusplus.com/reference/istream/istream/get/

Okay,
I'll just read the file, ignoring comments
and check white spaces with `std::isspace` function
https://ru.cppreference.com/w/cpp/string/byte/isspace