### PR TITLE
Fix #59: `PGM_IO` fails to read image without whitespace after comment hash sign

### DIFF
--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -46,16 +46,16 @@ std::shared_ptr<struct Image> PGM_IO::get_image() const
 
 std::string PGM_IO::read_pgm_instruction(std::istream& in)
 {
-    if (in.eof())
+    if (in.fail())
     {
         return "";
     }
     std::string current_input;
     in >> current_input;
-    while (!in.eof() && current_input[0] == '#')
+    while (in.good() && current_input[0] == '#')
     {
         in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        if (in.eof())
+        if (in.fail())
         {
             return "";
         }

--- a/include/pgm_io.cpp
+++ b/include/pgm_io.cpp
@@ -52,7 +52,7 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
     }
     std::string current_input;
     in >> current_input;
-    while (!in.eof() && current_input == "#")
+    while (!in.eof() && current_input[0] == '#')
     {
         in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         if (in.eof())
@@ -61,7 +61,7 @@ std::string PGM_IO::read_pgm_instruction(std::istream& in)
         }
         in >> current_input;
     }
-    if (current_input == "#")
+    if (current_input[0] == '#')
     {
         return "";
     }

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -37,11 +37,11 @@ BOOST_AUTO_TEST_CASE(read_image)
 {
     PGM_IO pgm_io;
     std::istringstream image_content{R"image(
-    # Grayscale image
+    ##### Grayscale image #####
     P2
     # 3 columns and 2 rows
     3 2
-    10 # Another pretty comment before a blank line
+    10 #Sticky comment
 
     0 1 2
     3 4 5


### PR DESCRIPTION
Once I've noticed
that comment may follow the `#` sign not after whitespace,
but immediately,
and this will ruin the reader,
so I should check the first symbol of read string against the `#`.

That I've thought
that the comment may start immediately after intensity number.
This would require more exhaustive parsing,
and the standard doesn't say a lot regarding possibility of such comments.
Though, as I understand,
each instruction of the file should be separated by a whitespace.
By this logic, comment should have a whitespace before it too,
or begin with the beginning of an input file.

Also, using knowledge from the commit where I tried to check the end of file
aa7e276b8e0c36821819a4a0da6af81ca7631f4a,
I change `eof` check to `good` and `fail` checks.