### PR TITLE
Close #61: Turn on documentation of private members

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -441,7 +441,7 @@ EXTRACT_ALL            = NO
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.


### PR DESCRIPTION
Private class members are not included into the documentation.
We fix this by setting `EXTRACT_PRIVATE` parameter to `YES`
in Doxyfile
https://www.stack.nl/~dimitri/doxygen/manual/config.html#cfg_extract_private