### PR TITLE
Close #20: Implement generation of constraint graph from disparity graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,8 +84,6 @@ Added
 
   - ``nodes_availability`` array that contains information about ability
     of each ``Node`` to be chosen,
-  - ``edges_availability`` array that contains information about ability
-    of each ``Edge`` to be chosen.
 
 .. Remove these two lines and one indentation level of the next two lines
     when you will release the first version.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -84,6 +84,18 @@ Added
 
   - ``nodes_availability`` array that contains information about ability
     of each ``Node`` to be chosen,
+  - ``disparity_graph`` constant pointer to ``DisparityGraph`` instance
+    from which the ``ConstraintGraph`` was built.
+  - ``threshold`` parameter to calculate `epsilon`-consistent nodes.
+
+- ``node_exists`` function to check whether specified ``Node``
+  is marked as available in ``ConstraintGraph``.
+- ``make_node_available`` mark specified ``Node``
+  as available in ``ConstraintGraph``.
+- ``make_node_unavailable`` mark specified ``Node``
+  as unavailable in ``ConstraintGraph``.
+- ``disparity2constraint`` function
+  to construct a ``ConstraintGraph`` given ``DisparityGraph``.
 
 .. Remove these two lines and one indentation level of the next two lines
     when you will release the first version.

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -284,11 +284,11 @@ struct ConstraintGraph
 
 ULONG node_index(const struct DisparityGraph& graph, struct Node node);
 void make_node_available(
-    struct ConstraintGraph& graph,
+    struct ConstraintGraph* graph,
     struct Node node
 );
 void make_node_unavailable(
-    struct ConstraintGraph& graph,
+    struct ConstraintGraph* graph,
     struct Node node
 );
 BOOL is_node_available(

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -45,11 +45,42 @@ using BOOL_ARRAY = std::vector<BOOL>;
 
 /**
  * \brief Structure to represent a graph with constraints
- * on choice of disparities for pixels (CSP problem).
+ * on choice of disparities for pixels (constraint satisfaction problem, CSP).
  *
  * After optimization performed on DisparityGraph,
  * it's needed to choose one labeling of many others
  * that satisfy constraints of the problem.
+ *
+ * Assuming the \f$\mathbb{I}\f$ to be an indicator function,
+ * we have the following formulas to set initial constraints for nodes
+ *
+ * \f[
+ *  b_i\left( d \right)
+ *  = \mathbb{I}\left(
+ *      q_i\left( d; \varphi \right)
+ *      - \min\limits_{\delta \in D}{q_i\left( \delta; \varphi \right)}
+ *      \le \varepsilon
+ *  \right),
+ *  \quad i \in I,
+ *  \quad d \in D
+ * \f]
+ *
+ * and edges
+ *
+ * \f[
+ *  a_{ij}\left( d, d' \right)
+ *  = \mathbb{I}\left(
+ *      g_{ij}\left( d, d'; \varphi \right)
+ *      - \min\limits_{\left\langle \delta, \delta' \right\rangle \in D^2}{
+ *          g_{ij}\left( \delta, \delta'; \varphi \right)}
+ *      \le \varepsilon
+ *  \right),
+ *  \quad i \in I,
+ *  \quad j \in N_i,
+ *  \quad \left\langle d, d' \right\rangle \in D^2.
+ * \f]
+ *
+ * There are cases when a constraint satisfaction problem
  */
 struct ConstraintGraph
 {
@@ -60,13 +91,6 @@ struct ConstraintGraph
      * `true` means that the node can be chosen under applied constraints.
      */
     BOOL_ARRAY nodes_availability;
-    /**
-     * \brief Array that contains markers for availability of edges.
-     *
-     * `false` means that the edge cannot be chosen.
-     * `true` means that the edge can be chosen under applied constraints.
-     */
-    BOOL_ARRAY edges_availability;
 };
 
 /**
@@ -81,55 +105,6 @@ struct ConstraintGraph
  * The same procedure is performed for each Edge:
  * if an Edge is worse than the best one not more than for `threshold`,
  * then it's marked as available.
- *
- * Denoting vertex penalty
- *
- * \f[
- *  q_i\left( d; \Phi \right)
- *  = \left\|
- *        R\left( i^x, i^y \right) - L\left( i^x + d, i^y \right)
- *    \right\|^p
- *    + \sum\limits_{j \in \mathcal{N}_i}
- *        \varphi_{i j}\left( d \right)
- * \f]
- *
- * and edge penalty
- *
- * \f[
- *  g_{ij}\left( d, d'; \Phi \right)
- *  = \left\| d - d' \right\|^p
- *    - \varphi_{i j}\left( d \right)
- *    - \varphi_{j i}\left( d' \right),
- * \f]
- *
- * assuming the \f$\mathbb{I}\f$ to be an indicator function,
- * we have the following formulas to set initial constraints for nodes
- *
- * \f[
- *  b_i\left( d \right)
- *  = \mathbb{I}\left(
- *      q_i\left( d; \Phi \right)
- *      - \min\limits_{\delta \in D}{q_i\left( \delta; \Phi \right)}
- *      \le \varepsilon
- *  \right),
- *  \quad i \in I,
- *  \quad d \in D
- * \f]
- *
- * and edges
- *
- * \f[
- *  a_{ij}\left( d, d' \right)
- *  = \mathbb{I}\left(
- *      g_{ij}\left( d, d'; \Phi \right)
- *      - \min\limits_{\left\langle \delta, \delta' \right\rangle \in D^2}{
- *          g_{ij}\left( \delta, \delta'; \Phi \right)}
- *      \le \varepsilon
- *  \right),
- *  \quad i \in I,
- *  \quad j \in N_i,
- *  \quad \left\langle d, d' \right\rangle \in D^2.
- * \f]
  */
 struct ConstraintGraph disparity2constraint(
     const struct DisparityGraph& disparity_graph,

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -306,7 +306,7 @@ BOOL is_node_available(
  * less than by `threshold`, is marked as available one.
  */
 struct ConstraintGraph disparity2constraint(
-    const struct DisparityGraph* disparity_graph,
+    const struct DisparityGraph& disparity_graph,
     FLOAT threshold
 );
 

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -262,29 +262,51 @@ using BOOL_ARRAY = std::vector<BOOL>;
 struct ConstraintGraph
 {
     /**
+     * \brief DisparityGraph instance
+     * for which the ConstraintGraph instance was created.
+     */
+    const struct DisparityGraph* disparity_graph;
+    /**
      * \brief Array that contains markers for availability of nodes.
      *
      * `false` means that the node cannot be chosen.
      * `true` means that the node can be chosen under applied constraints.
      */
     BOOL_ARRAY nodes_availability;
+    /**
+     * \brief Threshold to compare penalty of an edge with the minimal one
+     * against.
+     *
+     * \f$\varepsilon\f$ in formulas of the class description.
+     */
+    FLOAT threshold;
 };
 
+ULONG node_index(const struct DisparityGraph& graph, struct Node node);
+void make_node_available(
+    struct ConstraintGraph& graph,
+    struct Node node
+);
+void make_node_unavailable(
+    struct ConstraintGraph& graph,
+    struct Node node
+);
+BOOL is_node_available(
+    const struct ConstraintGraph& graph,
+    struct Node node
+);
 /**
  * \brief Build a CSP problem for given DisparityGraph.
  *
  * Corresponding ConstraintGraph should have
- * the same amount of nodes and edges as corresponding DisparityGraph.
+ * the same amount of nodes as corresponding DisparityGraph.
  *
  * First, all nodes and edges assumed to be unavailable.
  * Then, each Node that has a penalty that differs from the minimal
  * less than by `threshold`, is marked as available one.
- * The same procedure is performed for each Edge:
- * if an Edge is worse than the best one not more than for `threshold`,
- * then it's marked as available.
  */
 struct ConstraintGraph disparity2constraint(
-    const struct DisparityGraph& disparity_graph,
+    const struct DisparityGraph* disparity_graph,
     FLOAT threshold
 );
 

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -47,6 +47,8 @@ using BOOL_ARRAY = std::vector<BOOL>;
  * \brief Structure to represent a graph with constraints
  * on choice of disparities for pixels (constraint satisfaction problem, CSP).
  *
+ * \section csp-problem-statement Statement of the problem
+ *
  * After optimization performed on DisparityGraph,
  * it's needed to choose one labeling of many others
  * that satisfy constraints of the problem.
@@ -80,7 +82,182 @@ using BOOL_ARRAY = std::vector<BOOL>;
  *  \quad \left\langle d, d' \right\rangle \in D^2.
  * \f]
  *
- * There are cases when a constraint satisfaction problem
+ * The problem is to find a disparity map,
+ * for which all constraints are satisfied,
+ * i. e., all nodes contained in the disparity map exist
+ * and neighbors are connected by existent edges.
+ *
+ * There are cases when the constraint satisfaction problem.
+ * One of these cases is ours.
+ *
+ * \section csp-solution Solution
+ *
+ * It's easy to solve the problem in our case
+ * in iterative maneer.
+ * Let's note initial availability of nodes \f$b^0\f$
+ * and initial availability of edges \f$a^0\f$.
+ * They're already defined.
+ *
+ * Iteration of the algorithm is following
+ *
+ * - Take each node.
+ *  If the node is unavailable, it will never become available.
+ *  Otherwise,
+ *  check whether in each neighbor of pixel of the node
+ *  there exists an available edge between at least one node of the pixel
+ *  and current node.
+ *  If there is no connection with at least one neighboring pixel,
+ *  the node becomes unavailable.
+ * - Take each edge.
+ *  If the edge is unavailable, it will never become available.
+ *  Otherwise,
+ *  check whether both nodes of the edge are available.
+ *  If at least one node is unavailable,
+ *  the edge becomes unavailable.
+ *
+ * \f[
+ *  \begin{cases}
+ *      b^{k + 1}_i\left( d \right)
+ *      = b^k_i\left( d \right)
+ *          \wedge
+ *              \bigwedge\limits_{j \in \mathcal{N}_i}
+ *              \bigvee\limits_{d' \in D} a^k_{ij}\left( d, d' \right),
+ *      \quad \forall i \in I,
+ *      \quad \forall d \in D,
+ *      \\
+ *      a^{k + 1}_{ij}\left( d, d' \right)
+ *      = a^k_{ij}\left( d, d' \right)
+ *          \wedge b_i\left( d \right)
+ *          \wedge b_j\left( d' \right),
+ *      \quad \forall i \in I,
+ *      \quad \forall j \in N_i,
+ *      \quad \forall \left\langle d, d' \right\rangle \in D^2.
+ *  \end{cases}
+ * \f]
+ *
+ * Iteration is an execution of the step for all nodes and edges.
+ *
+ * If available nodes stay available
+ * and available edges stay available after the \f$k\f$th iteration,
+ * the algorighm is finished.
+ * Otherwise, go to \f$k + 1\f$st iteration.
+ *
+ * \section csp-memory Memory usage
+ *
+ * \subsection memory-issue Issue
+ *
+ * Number of edges is approximately
+ *
+ * \f[
+ *  \left| a \right|
+ *  \approx \left| I \right|
+ *  \cdot \max\limits_{i \in I}\left| \mathcal{N}_i \right|
+ *  \cdot \left| D \right|^2
+ * \f]
+ *
+ * This means, that for 1Mpx image \f$2^{10} \times 2^{10}\f$
+ * with maximal disparity equal to \f$128 = 2^7\f$
+ * and four neighbors (::NEIGHBORS_COUNT)
+ * number of edges is
+ *
+ * \f[
+ *  \left| a \right|
+ *  \approx \left( 2^{10} \right)^2 \cdot 4 \cdot \left( 2^7 \right)^2
+ *  = 2^{20} \cdot 2^2 \cdot 2^{14}
+ *  = 2^{36}
+ *  \approx 64 \cdot 10^9
+ * \f]
+ *
+ * Number of reparametrizetion elements under the same conditions is
+ *
+ * \f[
+ *  \left| \varphi \right|
+ *  \approx \left| I \right|
+ *  \cdot \max\limits_{i \in I}\left| \mathcal{N}_i \right|
+ *  \cdot \left| D \right|
+ *  = \left( 2^{10} \right)^2 \cdot 4 \cdot 2^7
+ *  = 2^{20} \cdot 2^2 \cdot 2^7
+ *  = 2^{29}
+ *  \approx 0.5 \cdot 10^9
+ * \f]
+ *
+ * If we use 4-byte floating point numbers
+ * for DisparityGraph::reparametrization,
+ * the DisparityGraph will cost \f$\approx\f$ 2GB.
+ * If we store information about availability of each edge in a single bit,
+ * memory consumption of the ConstraintGraph will be \f$\approx\f$ 8GB.
+ *
+ * It's problematic to store the last one,
+ * not speaking about parallel solution of different CSPs,
+ * because each instance should have its own copy of ConstraintGraph.
+ *
+ *
+ * \subsection memory-issue-solution Solution
+ *
+ * We can avoid usage of edge availability markers.
+ * In the problem above, usage of node availability is
+ *
+ * \f[
+ *  \left| b \right|
+ *  \approx \left| I \right| \cdot \left| D \right|
+ *  = 2^{10} \cdot 2^7
+ *  = 2^{17}
+ *  \approx 128 \cdot 10^3
+ * \f]
+ *
+ * Even if we will use 8 bytes per value,
+ * nodes' availability array will consume less than a megabyte
+ * of memory.
+ *
+ * We know, that unavailable edge will never become available.
+ * It may be unavailable for two reasons:
+ *
+ * -# It has failed comparison with \f$\varepsilon\f$;
+ * -# One of its node is/became unavailable.
+ *
+ * Thus, we can use the formula
+ *
+ * \f[
+ *  a^{k + 1}_{ij}\left( d, d' \right)
+ *  = \mathbb{I}\left(
+ *    g_{ij}\left( d, d'; \varphi \right)
+ *    - \min\limits_{\left\langle \delta, \delta' \right\rangle \in D^2}{
+ *        g_{ij}\left( \delta, \delta'; \varphi \right)}
+ *    \le \varepsilon
+ *  \right)
+ *  \wedge b^k_i\left( d \right)
+ *  \wedge b^k_j\left( d' \right).
+ * \f]
+ *
+ * Now, the formula for computation of
+ * \f$a^{k + 1}_{ij}\left( d, d' \right)\f$
+ * doesn't depend directly on \f$a^k\f$
+ *
+ * \f[
+ *  b^{k + 1}_i\left( d \right)
+ *  = b^k_i\left( d \right)
+ *      \wedge \bigwedge\limits_{j \in \mathcal{N}_i} \bigvee\limits_{d' \in D}
+ *          b^k_j\left( d' \right)
+ *          \wedge \mathbb{I}\left(
+ *            g_{ij}\left( d, d'; \varphi \right)
+ *            - \min\limits_{
+ *              \left\langle \delta, \delta' \right\rangle \in D^2}{
+ *              g_{ij}\left( \delta, \delta'; \varphi \right)}
+ *            \le \varepsilon
+ *          \right).
+ * \f]
+ *
+ * We can easily precompute each
+ * \f$\min\limits_{\left\langle \delta, \delta' \right\rangle \in D^2}
+ * {g_{ij}\left( \delta, \delta'; \varphi \right)}\f$:
+ * there are \f$4 \cdot \left| I \right|\f$ of them
+ * (one for each pair of neighboring pixels).
+ * In this case,
+ * computation of initial availability for an edge
+ * will cost almost only computation of its penalty.
+ *
+ * It's needed to store a pointer to a DisparityGraph in ConstraintGraph
+ * to use ::edge_penalty.
  */
 struct ConstraintGraph
 {

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -271,6 +271,20 @@ struct ConstraintGraph
      *
      * `false` means that the node cannot be chosen.
      * `true` means that the node can be chosen under applied constraints.
+     *
+     * Index of availability
+     * of specific Node from ConstraintGraph::nodes_availability
+     * can be calculated by formula
+     *
+     * \f[
+     *  k\left( \left\langle x, y \right\rangle, d \right) =
+     *  d + \max{D} \cdot \left( y + h \cdot x \right),
+     * \f]
+     *
+     * where \f$\left\langle x, y \right\rangle\f$
+     * are coordinates of Node::pixel,
+     * \f$i\f$ is an index of used neighbor
+     * and \f$d\f$ is a Node::disparity.
      */
     BOOL_ARRAY nodes_availability;
     /**
@@ -281,16 +295,44 @@ struct ConstraintGraph
      */
     FLOAT threshold;
 };
-
+/**
+ * \brief Get an index of ConstraintGraph::nodes_availability element
+ * using a Node.
+ *
+ * The function doesn't check existence of the Node.
+ * You should perform it by yourself
+ * using ::node_exists.
+ */
 ULONG node_index(const struct DisparityGraph& graph, struct Node node);
+/**
+ * \brief Mark specific Node as available (`true`).
+ *
+ * The function doesn't check existence of the Node.
+ * You should perform it by yourself
+ * using ::node_exists.
+ */
 void make_node_available(
     struct ConstraintGraph* graph,
     struct Node node
 );
+/**
+ * \brief Mark specific Node as unavailable (`false`).
+ *
+ * The function doesn't check existence of the Node.
+ * You should perform it by yourself
+ * using ::node_exists.
+ */
 void make_node_unavailable(
     struct ConstraintGraph* graph,
     struct Node node
 );
+/**
+ * \brief Check whether the Node is still available.
+ *
+ * The function doesn't check existence of the Node.
+ * You should perform it by yourself
+ * using ::node_exists.
+ */
 BOOL is_node_available(
     const struct ConstraintGraph& graph,
     struct Node node

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -203,16 +203,16 @@ const ULONG NEIGHBORS_COUNT = 4;
  *  \widetilde{E}\left( \varphi \right)
  *      = \sum\limits_{i \in I} \min_{d \in D}{\left[
  *          \left\|
- *              R\left( i^x, i^y \right) - L\left( i^x + k_i, i^y \right)
+ *              R\left( i^x, i^y \right) - L\left( i^x + d, i^y \right)
  *          \right\|^p
  *          + \sum\limits_{j \in \mathcal{N}_i}
- *              \varphi_{i j}\left( k_i \right)
+ *              \varphi_{i j}\left( d \right)
  *      \right]}
  *      + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
  *          \min_{d, d' \in D}{\left[
- *              \left\| k_i - k_j \right\|^p
- *              - \varphi_{i j}\left( k_i \right)
- *              - \varphi_{j i}\left( k_j \right)
+ *              \left\| d - d' \right\|^p
+ *              - \varphi_{i j}\left( d \right)
+ *              - \varphi_{j i}\left( d' \right)
  *          \right]}
  *  \neq \widetilde{E}
  * \f]
@@ -235,16 +235,16 @@ const ULONG NEIGHBORS_COUNT = 4;
  * \f[
  *  \sum\limits_{i \in I} \min_{d \in D}{\left[
  *      \left\|
- *          R\left( i^x, i^y \right) - L\left( i^x + k_i, i^y \right)
+ *          R\left( i^x, i^y \right) - L\left( i^x + d, i^y \right)
  *      \right\|^p
  *      + \sum\limits_{j \in \mathcal{N}_i}
- *          \varphi_{i j}\left( k_i \right)
+ *          \varphi_{i j}\left( d \right)
  *  \right]}
  *  + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
  *      \min_{d, d' \in D}{\left[
- *          \left\| k_i - k_j \right\|^p
- *          - \varphi_{i j}\left( k_i \right)
- *          - \varphi_{j i}\left( k_j \right)
+ *          \left\| d - d' \right\|^p
+ *          - \varphi_{i j}\left( d \right)
+ *          - \varphi_{j i}\left( d' \right)
  *      \right]}
  *  \to \max_{\varphi: I^2 \times K \rightarrow \mathbb{R}}
  * \f]

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -122,6 +122,31 @@ const ULONG NEIGHBORS_COUNT = 4;
  *      \left\| k_i - k_j \right\|^p
  * \f]
  *
+ * Denoting vertex penalty
+ *
+ * \f[
+ *  q_i\left( d \right)
+ *  = \left\|
+ *        R\left( i^x, i^y \right) - L\left( i^x + d, i^y \right)
+ *    \right\|^p
+ * \f]
+ *
+ * and edge penalty
+ *
+ * \f[
+ *  g_{ij}\left( d, d' \right)
+ *  = \left\| d - d' \right\|^p,
+ * \f]
+ *
+ * it's needed to solve
+ *
+ * \f[
+ *  \sum\limits_{i \in I} q_i\left( k_i \right)
+ *  + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
+ *      g_{ij}\left( k_i, k_j \right)
+ *  \to \min\limits_{k: I \rightarrow D}.
+ * \f]
+ *
  * \section dual-problem Dual problem
  *
  * It's easy to check that the following inequality holds
@@ -247,6 +272,34 @@ const ULONG NEIGHBORS_COUNT = 4;
  *          - \varphi_{j i}\left( d' \right)
  *      \right]}
  *  \to \max_{\varphi: I^2 \times K \rightarrow \mathbb{R}}
+ * \f]
+ *
+ * Introducing reparametrized vertex penalty
+ *
+ * \f[
+ *  q_i\left( d; \varphi \right)
+ *  = q_i\left( d \right)
+ *    + \sum\limits_{j \in \mathcal{N}_i}
+ *        \varphi_{i j}\left( d \right)
+ * \f]
+ *
+ * and reparametrized edge penalty
+ *
+ * \f[
+ *  g_{ij}\left( d, d'; \varphi \right)
+ *  = g_{ij}\left( d, d' \right)
+ *    - \varphi_{i j}\left( d \right)
+ *    - \varphi_{j i}\left( d' \right),
+ * \f]
+ *
+ * now we need to find such \f$\varphi\f$ that
+ *
+ * \f[
+ *  \sum\limits_{i \in I} \min\limits_{d \in D}{q_i\left( d; \varphi \right)}
+ *  + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
+ *      \min\limits_{\left\langle d, d' \right\rangle \in D^2}
+ *          g_{ij}\left( d, d'; \varphi \right)
+ *  \to \max\limits_{\varphi: I^2 \times K \rightarrow \mathbb{R}}.
  * \f]
  *
  * You can find more information in the following sources

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(
 )
 target_link_libraries(
     constraint_graph
+    disparity_graph
     image
 )
 
@@ -64,5 +65,6 @@ target_link_libraries(
     image
     pgm_io
     disparity_graph
+    constraint_graph
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -38,8 +38,7 @@ void make_node_available(
     struct Node node
 )
 {
-    graph.nodes_availability[node_index(*graph.disparity_graph, node)] =
-        static_cast<BOOL>(1);
+    graph.nodes_availability[node_index(*graph.disparity_graph, node)] = true;
 }
 
 void make_node_unavailable(
@@ -47,8 +46,7 @@ void make_node_unavailable(
     struct Node node
 )
 {
-    graph.nodes_availability[node_index(*graph.disparity_graph, node)] =
-        static_cast<BOOL>(0);
+    graph.nodes_availability[node_index(*graph.disparity_graph, node)] = false;
 }
 
 BOOL is_node_available(
@@ -76,7 +74,7 @@ struct ConstraintGraph disparity2constraint(
     fill(
         constraint_graph.nodes_availability.begin(),
         constraint_graph.nodes_availability.end(),
-        static_cast<BOOL>(0)
+        false
     );
 
     Node node{{0, 0}, 0};

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -95,11 +95,13 @@ struct ConstraintGraph disparity2constraint(
             ++node.pixel.row
         )
         {
+            node.disparity = 0;
             minimal_penalty = node_penalty(disparity_graph, node);
             for (
                 node.disparity = 0;
                 node.pixel.column + node.disparity
-                    < disparity_graph.left.width;
+                    < disparity_graph.left.width
+                && node.disparity <= disparity_graph.maximal_disparity;
                 ++node.disparity
             )
             {
@@ -112,7 +114,8 @@ struct ConstraintGraph disparity2constraint(
             for (
                 node.disparity = 0;
                 node.pixel.column + node.disparity
-                    < disparity_graph.left.width;
+                    < disparity_graph.left.width
+                && node.disparity <= disparity_graph.maximal_disparity;
                 ++node.disparity
             )
             {

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -38,7 +38,7 @@ void make_node_available(
     struct Node node
 )
 {
-    graph->nodes_availability[node_index(*graph.disparity_graph, node)] = true;
+    graph->nodes_availability[node_index(graph->disparity_graph, node)] = true;
 }
 
 void make_node_unavailable(
@@ -46,7 +46,7 @@ void make_node_unavailable(
     struct Node node
 )
 {
-    graph->nodes_availability[node_index(*graph.disparity_graph, node)] = false;
+    graph->nodes_availability[node_index(graph->disparity_graph, node)] = false;
 }
 
 BOOL is_node_available(

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -22,3 +22,106 @@
  * SOFTWARE.
  */
 #include <constraint_graph.hpp>
+
+#include <disparity_graph.hpp>
+
+#define MIN(x, y) (((x) <= (y)) ? (x) : (y))
+
+ULONG node_index(const struct DisparityGraph& graph, struct Node node)
+{
+    return node.disparity + graph.maximal_disparity
+        * (node.pixel.row + graph.right.height * node.pixel.column);
+}
+
+void make_node_available(
+    struct ConstraintGraph& graph,
+    struct Node node
+)
+{
+    graph.nodes_availability[node_index(*graph.disparity_graph, node)] =
+        static_cast<BOOL>(1);
+}
+
+void make_node_unavailable(
+    struct ConstraintGraph& graph,
+    struct Node node
+)
+{
+    graph.nodes_availability[node_index(*graph.disparity_graph, node)] =
+        static_cast<BOOL>(0);
+}
+
+BOOL is_node_available(
+    const struct ConstraintGraph& graph,
+    struct Node node
+)
+{
+    return graph.nodes_availability[node_index(*graph.disparity_graph, node)];
+}
+
+struct ConstraintGraph disparity2constraint(
+    const struct DisparityGraph& disparity_graph,
+    FLOAT threshold
+)
+{
+    struct ConstraintGraph constraint_graph{
+        &disparity_graph,
+        BOOL_ARRAY(
+            disparity_graph.right.width
+            * disparity_graph.right.height
+            * disparity_graph.maximal_disparity
+        ),
+        threshold
+    };
+    fill(
+        constraint_graph.nodes_availability.begin(),
+        constraint_graph.nodes_availability.end(),
+        static_cast<BOOL>(0)
+    );
+
+    Node node{{0, 0}, 0};
+    FLOAT minimal_penalty = 0;
+    for (
+        node.pixel.column = 0;
+        node.pixel.column < disparity_graph.right.width;
+        ++node.pixel.column
+    )
+    {
+        for (
+            node.pixel.row = 0;
+            node.pixel.row < disparity_graph.right.height;
+            ++node.pixel.row
+        )
+        {
+            minimal_penalty = node_penalty(disparity_graph, node);
+            for (
+                node.disparity = 0;
+                node.pixel.column + node.disparity
+                    < disparity_graph.left.width;
+                ++node.disparity
+            )
+            {
+                minimal_penalty = MIN(
+                    node_penalty(disparity_graph, node),
+                    minimal_penalty
+                );
+            }
+
+            for (
+                node.disparity = 0;
+                node.pixel.column + node.disparity
+                    < disparity_graph.left.width;
+                ++node.disparity
+            )
+            {
+                if (
+                    node_penalty(disparity_graph, node)
+                    - minimal_penalty <= threshold
+                )
+                {
+                    make_node_available(constraint_graph, node);
+                }
+            }
+        }
+    }
+}

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -34,19 +34,19 @@ ULONG node_index(const struct DisparityGraph& graph, struct Node node)
 }
 
 void make_node_available(
-    struct ConstraintGraph& graph,
+    struct ConstraintGraph* graph,
     struct Node node
 )
 {
-    graph.nodes_availability[node_index(*graph.disparity_graph, node)] = true;
+    graph->nodes_availability[node_index(*graph.disparity_graph, node)] = true;
 }
 
 void make_node_unavailable(
-    struct ConstraintGraph& graph,
+    struct ConstraintGraph* graph,
     struct Node node
 )
 {
-    graph.nodes_availability[node_index(*graph.disparity_graph, node)] = false;
+    graph->nodes_availability[node_index(*graph.disparity_graph, node)] = false;
 }
 
 BOOL is_node_available(
@@ -117,7 +117,7 @@ struct ConstraintGraph disparity2constraint(
                     - minimal_penalty <= threshold
                 )
                 {
-                    make_node_available(constraint_graph, node);
+                    make_node_available(&constraint_graph, node);
                 }
             }
         }

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -38,7 +38,8 @@ void make_node_available(
     struct Node node
 )
 {
-    graph->nodes_availability[node_index(graph->disparity_graph, node)] = true;
+    graph->nodes_availability[node_index(*(graph->disparity_graph), node)]
+        = true;
 }
 
 void make_node_unavailable(
@@ -46,7 +47,8 @@ void make_node_unavailable(
     struct Node node
 )
 {
-    graph->nodes_availability[node_index(graph->disparity_graph, node)] = false;
+    graph->nodes_availability[node_index(*(graph->disparity_graph), node)]
+        = false;
 }
 
 BOOL is_node_available(
@@ -54,7 +56,9 @@ BOOL is_node_available(
     struct Node node
 )
 {
-    return graph.nodes_availability[node_index(*graph.disparity_graph, node)];
+    return graph.nodes_availability[
+        node_index(*(graph.disparity_graph), node)
+    ];
 }
 
 struct ConstraintGraph disparity2constraint(

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -124,4 +124,5 @@ struct ConstraintGraph disparity2constraint(
             }
         }
     }
+    return constraint_graph;
 }

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -29,7 +29,7 @@
 
 ULONG node_index(const struct DisparityGraph& graph, struct Node node)
 {
-    return node.disparity + graph.maximal_disparity
+    return node.disparity + (graph.maximal_disparity + 1)
         * (node.pixel.row + graph.right.height * node.pixel.column);
 }
 
@@ -71,7 +71,7 @@ struct ConstraintGraph disparity2constraint(
         BOOL_ARRAY(
             disparity_graph.right.width
             * disparity_graph.right.height
-            * disparity_graph.maximal_disparity
+            * (disparity_graph.maximal_disparity + 1)
         ),
         threshold
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
     image.cpp
     pgm_io.cpp
     disparity_graph.cpp
+    constraint_graph.cpp
 )
 target_include_directories(test_executable PRIVATE ${BOOST_INCLUDE_DIRS})
 target_link_libraries(
@@ -34,6 +35,7 @@ target_link_libraries(
     image
     pgm_io
     disparity_graph
+    constraint_graph
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
 )
 target_compile_definitions(

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <boost/test/unit_test.hpp>
+
+#include <constraint_graph.hpp>
+#include <disparity_graph.hpp>
+#include <image.hpp>
+#include <pgm_io.hpp>
+
+BOOST_AUTO_TEST_SUITE(DisparityGraphTest)
+
+BOOST_AUTO_TEST_CASE(check_black_images)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    2
+    0 0 0
+    0 0 0
+    )image"};
+
+    image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{image, image, 2};
+    struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 1)};
+    BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
+    BOOST_CHECK_CLOSE(constraint_graph.threshold, 1, 1);
+
+    struct Node node;
+    for (
+        node.pixel.column = 0;
+        node.pixel.column < disparity_graph.right.width;
+        ++node.pixel.column
+    )
+    {
+        for (
+            node.pixel.row = 0;
+            node.pixel.row < disparity_graph.right.height;
+            ++node.pixel.row
+        )
+        {
+            for (
+                node.disparity = 0;
+                node.disparity < disparity_graph.maximal_disparity;
+                ++node.disparity
+            )
+            {
+                BOOST_CHECK_EQUAL(
+                    is_node_available(constraint_graph, node),
+                    node.pixel.column + node.disparity
+                    < disparity_graph.left.width
+                );
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 1, 1);
 
-    struct Node node;
+    struct Node node{{0, 0}, 0};
     for (
         node.pixel.column = 0;
         node.pixel.column < disparity_graph.right.width;


### PR DESCRIPTION
Changes
=======

Add

- ``disparity_graph`` constant pointer to ``DisparityGraph`` instance
    from which the ``ConstraintGraph`` was built.
- ``threshold`` parameter to calculate `epsilon`-consistent nodes.
- ``node_exists`` function to check whether specified ``Node``
  is marked as available in ``ConstraintGraph``.
- ``make_node_available`` mark specified ``Node``
  as available in ``ConstraintGraph``.
- ``make_node_unavailable`` mark specified ``Node``
  as unavailable in ``ConstraintGraph``.
- ``disparity2constraint`` function
  to construct a ``ConstraintGraph`` given ``DisparityGraph``

Remove ``edges_availability`` array, because of memory issues.

Memory issues
=============

Edges information of constraint graph may consume a lot of memory,
so it was decided to remove it.
Though, a function for their availability calculation was introduced instead.

New knowledge
=============

you can create an enumerated list in Doxygen
using `-#`.
This will make numbers automatically.
https://www.star.bnl.gov/public/comp/sofi/doxygen/lists.html 

Useful rule regarding usage of pointers instead of non-const references.
This makes change of passed argument explicit
https://google.github.io/styleguide/cppguide.html#Reference_Arguments
Inspected by Clang Tidy
https://clang.llvm.org/extra/clang-tidy/checks/google-runtime-references.html

It's appeared that the tolerance parameter in `BOOST_CHECK_CLOSE`
is an accuracy specified in percents.
This means that `0.5` is not a `50`%, but only `0.5`%.

Oh no
=====

I've found out that I have wrong calculation of indices.
Should fix the issue #71 now.
Will it end?
I want to build a 3D map by stereo pairs!