### PR TITLE
Close #73: Change signature of `node_exists` function

### DIFF
--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -486,14 +486,15 @@ bool neighborhood_exists_fast(
 /**
  * \brief Check existence of provided Node.
  *
- * Node exists if position of its pixel doesn't overflow its image
- * and corresponding pixel (calculated by the disparity)
- * doesn't overflow another image.
+ * Node exists if position of its pixel doesn't overflow
+ * DisparityGraph::right image,
+ * corresponding pixel (calculated by the disparity)
+ * doesn't overflow the DisparityGraph::left image,
+ * and its disparity doesn't overflow
+ * the maximal allowed.
  */
 bool node_exists(
-    ULONG maximal_disparity,
-    const struct Image& image,
-    const struct Image& another_image,
+    const struct DisparityGraph& graph,
     struct Node node
 );
 

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -168,17 +168,15 @@ bool neighborhood_exists_fast(
 }
 
 bool node_exists(
-    ULONG maximal_disparity,
-    const struct Image& image,
-    const struct Image& another_image,
+    const struct DisparityGraph& graph,
     struct Node node
 )
 {
     return !(
-        node.disparity > maximal_disparity
-        || node.pixel.row >= image.height
-        || node.pixel.column >= image.width
-        || node.pixel.column + node.disparity >= another_image.width
+        node.disparity > graph.maximal_disparity
+        || node.pixel.row >= graph.right.height
+        || node.pixel.column >= graph.right.width
+        || node.pixel.column + node.disparity >= graph.left.width
     );
 }
 
@@ -187,11 +185,11 @@ bool edge_exists(
     struct Edge edge
 )
 {
-    if (!node_exists(graph.maximal_disparity, graph.left, graph.right, edge.node))
+    if (!node_exists(graph, edge.node))
     {
         return false;
     }
-    if (!node_exists(graph.maximal_disparity, graph.left, graph.right, edge.neighbor))
+    if (!node_exists(graph, edge.neighbor))
     {
         return false;
     }

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -29,6 +29,42 @@
 
 BOOST_AUTO_TEST_SUITE(DisparityGraphTest)
 
+BOOST_AUTO_TEST_CASE(check_nodes_existence)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    2
+    0 0 0
+    0 0 0
+    )image"};
+
+    image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{image, image, 1};
+
+    for (ULONG row = 0; row < 2; ++row)
+    {
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 2}, 0}));
+
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 1}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 1}));
+
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 0}, 2}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 1}, 2}));
+
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 2}, 1}));
+    }
+    BOOST_CHECK(!node_exists(disparity_graph, {{2, 0}, 0}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{0, 3}, 2}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{2, 3}, 2}));
+}
+
 BOOST_AUTO_TEST_CASE(check_neighborhood)
 {
     PGM_IO pgm_io;


### PR DESCRIPTION
The function looks weird.
We know that node corresponds to a pixel on the right image,
so providing disparity graph is enough to fetch needed parameters.

Make the function to consume disparity graph and node.
Also, test that it works right.