### PR TITLE
Fix #71: Wrong indexing of reparametrization vector

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,7 @@ Added
   - ``left`` image,
   - ``right`` image
     (made on a camera located to the right of the ``left`` image),
-  - ``maximal_disparity`` is a limit for disparity
+  - ``disparity_levels`` is the number of different disparity levels
     (the more it is, the more memory the graph consumes),
   - ``reparametrization`` that allows to solve the dual problem.
 

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -82,9 +82,9 @@ const ULONG NEIGHBORS_COUNT = 4;
  * Disparity is a difference
  * between number of a column of a pixel of the left image
  * and number of a column of corresponding pixel of the right image.
- * Given maximal disparity (DisparityGraph::maximal_disparity)
- * \f$\max{D}\f$ and denoting
- * \f$D = \left\{ 1, \dots, \max{D} \right\}\f$,
+ * Given number of disparities (DisparityGraph::disparity_levels)
+ * \f$\left| D \right|\f$ and denoting
+ * \f$D = \left\{ 0, \dots, \max{D} \right\}\f$,
  * correspondence function is called labeling and its signature is
  *
  * \f[
@@ -327,10 +327,26 @@ struct DisparityGraph
      */
     struct Image right;
     /**
-     * \brief Maximal distance between positions of pixels
-     * that see the same 3D point.
+     * \brief Number of disparity levels.
+     *
+     * Number of disparity levels is more generic value
+     * than maximal disparity level.
+     * This measure may be applied in the case
+     * when we use pyramidal disparity map search
+     * and thus have initial values for different pixels.
+     * In this situation,
+     * we can set the disparity map we've got
+     * as the middle of disparity scale of a pixel,
+     * and find finer disparity map
+     * using DisparityGraph::disparity_levels disparity values.
+     *
+     * For now,
+     * we assume the minimal disparity for each pixel to be equal `0`,
+     * so the DisparityGraph::disparity_levels is used simply as
+     * \f$\max{D} - 1\f$ in set of available disparities
+     * \f$D = \left\{ 0, 1, \dots, \max{D} - 1 \right\}\f$.
      */
-    ULONG maximal_disparity;
+    ULONG disparity_levels;
     /**
      * \brief Reparametrization is a helpful vector
      * for the optimization problem.
@@ -363,10 +379,8 @@ struct DisparityGraph
      * \f[
      *  k\left( \left\langle x, y \right\rangle, i, d \right) =
      *      y + h \cdot \left(
-     *          d + \max{D} \cdot \left(
-     *              i + \max_j{\mathcal{N}_j} \cdot \left(
-     *                      x \cdot w
-     *                  \right)
+     *          d + \left| D \right| \cdot \left(
+     *              i + \max_j{\mathcal{N}_j} \cdot x \cdot w
      *              \right)
      *          \right),
      * \f]
@@ -384,7 +398,7 @@ struct DisparityGraph
     DisparityGraph(
         struct Image left,
         struct Image right,
-        ULONG maximal_disparity
+        ULONG disparity_levels
     );
 };
 

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -486,14 +486,15 @@ bool neighborhood_exists_fast(
 /**
  * \brief Check existence of provided Node.
  *
- * Node exists if position of its pixel doesn't overflow its image
- * and corresponding pixel (calculated by the disparity)
- * doesn't overflow another image.
+ * Node exists if position of its pixel doesn't overflow
+ * DisparityGraph::right image,
+ * corresponding pixel (calculated by the disparity)
+ * doesn't overflow the DisparityGraph::left image,
+ * and its disparity doesn't overflow
+ * the maximal allowed.
  */
 bool node_exists(
-    ULONG maximal_disparity,
-    const struct Image& image,
-    const struct Image& another_image,
+    const struct DisparityGraph& graph,
     struct Node node
 );
 

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -29,7 +29,7 @@
 
 ULONG node_index(const struct DisparityGraph& graph, struct Node node)
 {
-    return node.disparity + (graph.maximal_disparity + 1)
+    return node.disparity + graph.disparity_levels
         * (node.pixel.row + graph.right.height * node.pixel.column);
 }
 
@@ -71,7 +71,7 @@ struct ConstraintGraph disparity2constraint(
         BOOL_ARRAY(
             disparity_graph.right.width
             * disparity_graph.right.height
-            * (disparity_graph.maximal_disparity + 1)
+            * disparity_graph.disparity_levels
         ),
         threshold
     };
@@ -101,7 +101,7 @@ struct ConstraintGraph disparity2constraint(
                 node.disparity = 0;
                 node.pixel.column + node.disparity
                     < disparity_graph.left.width
-                && node.disparity <= disparity_graph.maximal_disparity;
+                && node.disparity < disparity_graph.disparity_levels;
                 ++node.disparity
             )
             {
@@ -115,7 +115,7 @@ struct ConstraintGraph disparity2constraint(
                 node.disparity = 0;
                 node.pixel.column + node.disparity
                     < disparity_graph.left.width
-                && node.disparity <= disparity_graph.maximal_disparity;
+                && node.disparity < disparity_graph.disparity_levels;
                 ++node.disparity
             )
             {

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -174,7 +174,7 @@ bool node_exists(
 )
 {
     return !(
-        node.disparity > graph.maximal_disparity
+        node.disparity >= graph.disparity_levels
         || node.pixel.row >= graph.right.height
         || node.pixel.column >= graph.right.width
         || node.pixel.column + node.disparity >= graph.left.width

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -32,11 +32,11 @@
 DisparityGraph::DisparityGraph(
     struct Image left,
     struct Image right,
-    ULONG maximal_disparity
+    ULONG disparity_levels
 )
     : left{std::move(left)}
     , right{std::move(right)}
-    , maximal_disparity{maximal_disparity}
+    , disparity_levels{disparity_levels}
 {
     if (!image_valid(this->left))
     {
@@ -46,20 +46,21 @@ DisparityGraph::DisparityGraph(
     {
         throw std::invalid_argument("Right image is invalid.");
     }
-    if (this->maximal_disparity == 0)
+    if (this->disparity_levels <= 1)
     {
         throw std::invalid_argument(
-            "Maximal disparity should be greater than zero."
+            "Number of disparity levels should be greater than one."
         );
     }
-    if (this->maximal_disparity >= this->left.width)
+    if (this->disparity_levels > this->left.width)
     {
         throw std::invalid_argument(
-            "Maximal disparity should be less than width of the left image. "
+            "Number of disparity levels "
+            "should not be greater than width of the left image. "
             "Width of the left image is "
             + std::to_string(this->left.width)
-            + ". Provided maximal disparity is "
-            + std::to_string(this->maximal_disparity)
+            + ". Provided number of disparity levels is "
+            + std::to_string(this->disparity_levels)
             + "."
         );
     }
@@ -101,7 +102,7 @@ DisparityGraph::DisparityGraph(
         this->left.width
         * this->left.height
         * NEIGHBORS_COUNT
-        * this->maximal_disparity
+        * this->disparity_levels
     );
     fill(
         this->reparametrization.begin(),
@@ -230,7 +231,7 @@ ULONG reparametrization_index_fast(
     index += node.pixel.column;
     index *= NEIGHBORS_COUNT;
     index += neighbor_index;
-    index *= graph.maximal_disparity;
+    index *= graph.disparity_levels;
     index += node.disparity;
     index *= graph.left.height;
     index += node.pixel.row;

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -168,17 +168,15 @@ bool neighborhood_exists_fast(
 }
 
 bool node_exists(
-    ULONG maximal_disparity,
-    const struct Image& image,
-    const struct Image& another_image,
+    const struct DisparityGraph& graph,
     struct Node node
 )
 {
     return !(
-        node.disparity > maximal_disparity
-        || node.pixel.row >= image.height
-        || node.pixel.column >= image.width
-        || node.pixel.column + node.disparity >= another_image.width
+        node.disparity > graph.maximal_disparity
+        || node.pixel.row >= graph.right.height
+        || node.pixel.column >= graph.right.width
+        || node.pixel.column + node.disparity >= graph.left.width
     );
 }
 
@@ -187,11 +185,11 @@ bool edge_exists(
     struct Edge edge
 )
 {
-    if (!node_exists(graph.maximal_disparity, graph.left, graph.right, edge.node))
+    if (!node_exists(graph, edge.node))
     {
         return false;
     }
-    if (!node_exists(graph.maximal_disparity, graph.left, graph.right, edge.neighbor))
+    if (!node_exists(graph, edge.neighbor))
     {
         return false;
     }

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -23,9 +23,9 @@ int main(int argc, char* argv[]) try
         ("right-image,r",
          boost::program_options::value<std::string>(),
          "Right image")
-        ("maximal-disparity,d",
+        ("disparity-levels,d",
          boost::program_options::value<std::string>(),
-         "Maximal disparity");
+         "Number of disparity levels");
 
     boost::program_options::variables_map vm;
     try
@@ -55,21 +55,21 @@ int main(int argc, char* argv[]) try
             struct Image right_image{
                 read_image(vm["right-image"].as<std::string>())
             };
-            ULONG maximal_disparity = 0;
-            if (vm.count("maximal-disparity") == 0)
+            ULONG disparity_levels = 0;
+            if (vm.count("disparity-levels") == 0)
             {
-                maximal_disparity = left_image.width - 1;
+                disparity_levels = left_image.width;
             }
             else
             {
-                maximal_disparity = std::stoul(
-                    vm["maximal-disparity"].as<std::string>()
+                disparity_levels = std::stoul(
+                    vm["disparity-levels"].as<std::string>()
                 );
             }
             struct DisparityGraph disparity_graph{
                 left_image,
                 right_image,
-                maximal_disparity
+                disparity_levels
             };
         }
         catch (std::invalid_argument& e)

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(check_nodes_indexing)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{image, image, 2};
+    struct DisparityGraph disparity_graph{image, image, 3};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 1)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
 
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{image, image, 2};
+    struct DisparityGraph disparity_graph{image, image, 3};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 1)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 1, 1);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
         {
             for (
                 node.disparity = 0;
-                node.disparity < disparity_graph.maximal_disparity;
+                node.disparity < disparity_graph.disparity_levels;
                 ++node.disparity
             )
             {
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{image, image, 2};
+    struct DisparityGraph disparity_graph{image, image, 3};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 128 * 128)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 128 * 128, 1);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(check_disparity_loop)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 1};
+    struct DisparityGraph disparity_graph{left_image, right_image, 2};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 15)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 15, 1);
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(check_minimal_node_value_calculation)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 0.5)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 0.5, 1);

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -29,6 +29,42 @@
 
 BOOST_AUTO_TEST_SUITE(DisparityGraphTest)
 
+BOOST_AUTO_TEST_CASE(check_nodes_existence)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    2
+    0 0 0
+    0 0 0
+    )image"};
+
+    image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{image, image, 1};
+
+    for (ULONG row = 0; row < 2; ++row)
+    {
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 2}, 0}));
+
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 1}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 1}));
+
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 0}, 2}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 1}, 2}));
+
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 2}, 1}));
+    }
+    BOOST_CHECK(!node_exists(disparity_graph, {{2, 0}, 0}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{0, 3}, 2}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{2, 3}, 2}));
+}
+
 BOOST_AUTO_TEST_CASE(check_neighborhood)
 {
     PGM_IO pgm_io;

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(check_neighborhood)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {0, 1}));
     BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {1, 0}));
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(check_edges_existence)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 1};
+    struct DisparityGraph disparity_graph{left_image, right_image, 2};
 
     BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 0}}));
     BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 1}}));
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(check_continuity_constraint)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{0, 1}, 0}}));
     BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 1}, 0}, {{0, 0}, 2}}));
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(check_initial_edges_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     BOOST_CHECK_CLOSE(
         edge_penalty(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 0}}),
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(check_initial_nodes_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 1.0, 0.5);
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0.0, 0.5);
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(check_edges_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     disparity_graph.reparametrization[
         reparametrization_index(disparity_graph, {{0, 0}, 0}, {0, 1})
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(check_nodes_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     disparity_graph.reparametrization[
         reparametrization_index(disparity_graph, {{0, 0}, 0}, {0, 1})

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(check_nodes_existence)
     image_content >> pgm_io;
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
-    struct DisparityGraph disparity_graph{image, image, 1};
+    struct DisparityGraph disparity_graph{image, image, 2};
 
     for (ULONG row = 0; row < 2; ++row)
     {
@@ -97,42 +97,6 @@ BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 2}, 3), 23);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 0), 24);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 1}, 2}, 3), 47);
-}
-
-BOOST_AUTO_TEST_CASE(check_nodes_existence)
-{
-    PGM_IO pgm_io;
-    std::istringstream image_content{R"image(
-    P2
-    3 2
-    2
-    0 0 0
-    0 0 0
-    )image"};
-
-    image_content >> pgm_io;
-    BOOST_REQUIRE(pgm_io.get_image());
-    struct Image image{*pgm_io.get_image()};
-
-    struct DisparityGraph disparity_graph{image, image, 2};
-
-    for (ULONG row = 0; row < 2; ++row)
-    {
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 2}, 0}));
-
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 1}));
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 1}));
-
-        BOOST_CHECK(!node_exists(disparity_graph, {{row, 0}, 2}));
-        BOOST_CHECK(!node_exists(disparity_graph, {{row, 1}, 2}));
-
-        BOOST_CHECK(!node_exists(disparity_graph, {{row, 2}, 1}));
-    }
-    BOOST_CHECK(!node_exists(disparity_graph, {{2, 0}, 0}));
-    BOOST_CHECK(!node_exists(disparity_graph, {{0, 3}, 2}));
-    BOOST_CHECK(!node_exists(disparity_graph, {{2, 3}, 2}));
 }
 
 BOOST_AUTO_TEST_CASE(check_neighborhood)

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -99,6 +99,42 @@ BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 1}, 2}, 3), 47);
 }
 
+BOOST_AUTO_TEST_CASE(check_nodes_existence)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    2
+    0 0 0
+    0 0 0
+    )image"};
+
+    image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{image, image, 2};
+
+    for (ULONG row = 0; row < 2; ++row)
+    {
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 2}, 0}));
+
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 1}));
+        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 1}));
+
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 0}, 2}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 1}, 2}));
+
+        BOOST_CHECK(!node_exists(disparity_graph, {{row, 2}, 1}));
+    }
+    BOOST_CHECK(!node_exists(disparity_graph, {{2, 0}, 0}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{0, 3}, 2}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{2, 3}, 2}));
+}
+
 BOOST_AUTO_TEST_CASE(check_neighborhood)
 {
     PGM_IO pgm_io;

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -29,6 +29,41 @@
 
 BOOST_AUTO_TEST_SUITE(DisparityGraphTest)
 
+BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    2
+    0 0 0
+    0 0 0
+    )image"};
+
+    image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{image, image, 3};
+
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 0), 0);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 0}, 0), 1);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 1}, 0), 2);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 2}, 0), 4);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 2}, 0), 5);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 1), 6);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 0}, 1), 7);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 1}, 1), 8);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 1}, 1), 9);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 2}, 1), 10);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 2}, 1), 11);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 2), 12);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 3), 18);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 2}, 3), 23);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 0), 24);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 1}, 2}, 3), 47);
+}
+
 BOOST_AUTO_TEST_CASE(check_neighborhood)
 {
     PGM_IO pgm_io;


### PR DESCRIPTION
Change maximal_disparity to a parameter that will signify a number
that is greater by `1` that maximal allowed disparity
called `disparity_levels`.
This will need another validation, another tests,
another documentation for the parameters.

It is convenient for

- pyramidal disparity refinement,
  when we use an image with lower resolution to consume less memory,
  and then pass its resulting disparity map to the application
  as initial values for disparity map calculation
  on an image with original resolution
- subpixel matching,
  where single disparity level means not an offset by a pixel,
  but an offset by a part of a pixel (half, quarter etc.)