### PR TITLE
Close #74: Change `column` to `x` and `row` to `y` in `Pixel` and swap them

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,8 +29,8 @@ Added
 - ``Pixel`` structure to represent position of a pixel.
   Contains
 
-  - ``row`` (vertical offset) of a pixel,
   - ``column`` (horizontal offset) of a pixel.
+  - ``row`` (vertical offset) of a pixel,
 
 - ``image_valid`` function to check validity of ``Image``.
 - ``get_pixel_index`` to calculate index of given pixel

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,8 +29,8 @@ Added
 - ``Pixel`` structure to represent position of a pixel.
   Contains
 
-  - ``column`` (horizontal offset) of a pixel.
-  - ``row`` (vertical offset) of a pixel,
+  - ``x`` (horizontal offset, column) of a pixel.
+  - ``y`` (vertical offset, row) of a pixel,
 
 - ``image_valid`` function to check validity of ``Image``.
 - ``get_pixel_index`` to calculate index of given pixel

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -367,10 +367,10 @@ struct DisparityGraph
      *
      * Used "dimensions" are following (upper ones are more nested):
      *
-     * - Pixel::row of Node::pixel,
+     * - Pixel::y of Node::pixel,
      * - Node::disparity,
      * - Index of current neighbor of Node instance,
-     * - Pixel::column of Node::pixel
+     * - Pixel::x of Node::pixel
      *
      * Index of an element of the DisparityGraph::reparametrization
      * for specific Node and neighbor index

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -91,11 +91,11 @@ struct Pixel
     /**
      * \brief Column (horizontal offset) of the pixel.
      */
-    ULONG column;
+    ULONG x;
     /**
      * \brief Row (vertical offset) of the pixel.
      */
-    ULONG row;
+    ULONG y;
 };
 
 /**

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -89,13 +89,13 @@ struct Image
 struct Pixel
 {
     /**
-     * \brief Row (vertical offset) of the pixel.
-     */
-    ULONG row;
-    /**
      * \brief Column (horizontal offset) of the pixel.
      */
     ULONG column;
+    /**
+     * \brief Row (vertical offset) of the pixel.
+     */
+    ULONG row;
 };
 
 /**

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -30,7 +30,7 @@
 ULONG node_index(const struct DisparityGraph& graph, struct Node node)
 {
     return node.disparity + graph.disparity_levels
-        * (node.pixel.row + graph.right.height * node.pixel.column);
+        * (node.pixel.y + graph.right.height * node.pixel.x);
 }
 
 void make_node_available(
@@ -84,22 +84,22 @@ struct ConstraintGraph disparity2constraint(
     Node node{{0, 0}, 0};
     FLOAT minimal_penalty = 0;
     for (
-        node.pixel.column = 0;
-        node.pixel.column < disparity_graph.right.width;
-        ++node.pixel.column
+        node.pixel.x = 0;
+        node.pixel.x < disparity_graph.right.width;
+        ++node.pixel.x
     )
     {
         for (
-            node.pixel.row = 0;
-            node.pixel.row < disparity_graph.right.height;
-            ++node.pixel.row
+            node.pixel.y = 0;
+            node.pixel.y < disparity_graph.right.height;
+            ++node.pixel.y
         )
         {
             node.disparity = 0;
             minimal_penalty = node_penalty(disparity_graph, node);
             for (
                 node.disparity = 0;
-                node.pixel.column + node.disparity
+                node.pixel.x + node.disparity
                     < disparity_graph.left.width
                 && node.disparity < disparity_graph.disparity_levels;
                 ++node.disparity
@@ -113,7 +113,7 @@ struct ConstraintGraph disparity2constraint(
 
             for (
                 node.disparity = 0;
-                node.pixel.column + node.disparity
+                node.pixel.x + node.disparity
                     < disparity_graph.left.width
                 && node.disparity < disparity_graph.disparity_levels;
                 ++node.disparity

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -116,23 +116,23 @@ ULONG neighbor_index(
     struct Pixel neighbor
 )
 {
-    if (pixel.column != neighbor.column && pixel.row != neighbor.row)
+    if (pixel.x != neighbor.x && pixel.y != neighbor.y)
     {
         return NEIGHBORS_COUNT;
     }
-    if (pixel.column + 1 == neighbor.column)
+    if (pixel.x + 1 == neighbor.x)
     {
         return 0;
     }
-    if (pixel.column == neighbor.column + 1)
+    if (pixel.x == neighbor.x + 1)
     {
         return 1;
     }
-    if (pixel.row + 1 == neighbor.row)
+    if (pixel.y + 1 == neighbor.y)
     {
         return 2;
     }
-    if (pixel.row == neighbor.row + 1)
+    if (pixel.y == neighbor.y + 1)
     {
         return 3;
     }
@@ -159,12 +159,12 @@ bool neighborhood_exists_fast(
 )
 {
     return !(neighbor_index > 3
-        || pixel.row >= graph.right.height
-        || pixel.column >= graph.right.width
-        || (pixel.column + 1 == graph.left.width && neighbor_index == 0)
-        || (pixel.column == 0 && neighbor_index == 1)
-        || (pixel.row + 1 == graph.left.height && neighbor_index == 2)
-        || (pixel.row == 0 && neighbor_index == 3)
+        || pixel.y >= graph.right.height
+        || pixel.x >= graph.right.width
+        || (pixel.x + 1 == graph.left.width && neighbor_index == 0)
+        || (pixel.x == 0 && neighbor_index == 1)
+        || (pixel.y + 1 == graph.left.height && neighbor_index == 2)
+        || (pixel.y == 0 && neighbor_index == 3)
     );
 }
 
@@ -175,9 +175,9 @@ bool node_exists(
 {
     return !(
         node.disparity >= graph.disparity_levels
-        || node.pixel.row >= graph.right.height
-        || node.pixel.column >= graph.right.width
-        || node.pixel.column + node.disparity >= graph.left.width
+        || node.pixel.y >= graph.right.height
+        || node.pixel.x >= graph.right.width
+        || node.pixel.x + node.disparity >= graph.left.width
     );
 }
 
@@ -199,17 +199,17 @@ bool edge_exists(
         return false;
     }
 
-    if (edge.node.pixel.row != edge.neighbor.pixel.row)
+    if (edge.node.pixel.y != edge.neighbor.pixel.y)
     {
         return true;
     }
 
-    if (edge.node.pixel.column + 1 == edge.neighbor.pixel.column
+    if (edge.node.pixel.x + 1 == edge.neighbor.pixel.x
         && edge.node.disparity > edge.neighbor.disparity + 1)
     {
         return false;
     }
-    if (edge.node.pixel.column == edge.neighbor.pixel.column + 1
+    if (edge.node.pixel.x == edge.neighbor.pixel.x + 1
         && edge.node.disparity + 1 < edge.neighbor.disparity)
     {
         return false;
@@ -226,13 +226,13 @@ ULONG reparametrization_index_fast(
 {
     ULONG index = 0;
     index *= graph.right.width;
-    index += node.pixel.column;
+    index += node.pixel.x;
     index *= NEIGHBORS_COUNT;
     index += neighbor_index;
     index *= graph.disparity_levels;
     index += node.disparity;
     index *= graph.left.height;
-    index += node.pixel.row;
+    index += node.pixel.y;
 
     return index;
 }
@@ -301,7 +301,7 @@ FLOAT edge_penalty(const struct DisparityGraph& graph, struct Edge edge)
 FLOAT node_penalty(const struct DisparityGraph& graph, struct Node node)
 {
     Pixel left_pixel = node.pixel;
-    left_pixel.column += node.disparity;
+    left_pixel.x += node.disparity;
     return
         SQR(TO_FLOAT(get_pixel_value(graph.right, node.pixel))
             - TO_FLOAT(get_pixel_value(graph.left, left_pixel)))

--- a/lib/image.cpp
+++ b/lib/image.cpp
@@ -41,7 +41,7 @@ bool image_valid(const struct Image& image)
 
 ULONG get_pixel_index(const struct Image& image, struct Pixel pixel)
 {
-    return image.width * pixel.row + pixel.column;
+    return image.width * pixel.y + pixel.x;
 }
 
 ULONG get_pixel_value(const struct Image& image, struct Pixel pixel)

--- a/lib/pgm_io.cpp
+++ b/lib/pgm_io.cpp
@@ -104,7 +104,7 @@ std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io)
     {
         for (unsigned column = 0; column < image->width; ++column)
         {
-            out << image->data[get_pixel_index(*image, {row, column})];
+            out << image->data[get_pixel_index(*image, {column, row})];
             if (column == 0 || (column + 1) % PGM_IO::MAX_NUMBERS_PER_ROW != 0)
             {
                 if (column + 1 < image->width)
@@ -162,7 +162,7 @@ std::istream& operator>>(std::istream& in, PGM_IO& ppm_io)
         {
             try
             {
-                image->data[get_pixel_index(*image, {row, column})] =
+                image->data[get_pixel_index(*image, {column, row})] =
                     std::stoul(PGM_IO::read_pgm_instruction(in));
             }
             catch (std::invalid_argument&)

--- a/lib/pgm_io.cpp
+++ b/lib/pgm_io.cpp
@@ -100,21 +100,21 @@ std::ostream& operator<<(std::ostream& out, const PGM_IO& ppm_io)
     out << PGM_IO::FORMAT_CODE << std::endl;
     out << image->width << " " << image->height << std::endl;
     out << image->max_value << std::endl;
-    for (unsigned row = 0; row < image->height; ++row)
+    for (ULONG y = 0; y < image->height; ++y)
     {
-        for (unsigned column = 0; column < image->width; ++column)
+        for (ULONG x = 0; x < image->width; ++x)
         {
-            out << image->data[get_pixel_index(*image, {column, row})];
-            if (column == 0 || (column + 1) % PGM_IO::MAX_NUMBERS_PER_ROW != 0)
+            out << image->data[get_pixel_index(*image, {x, y})];
+            if (x == 0 || (x + 1) % PGM_IO::MAX_NUMBERS_PER_ROW != 0)
             {
-                if (column + 1 < image->width)
+                if (x + 1 < image->width)
                 {
                     out << " ";
                 }
             }
             else
             {
-                if (column + 1 < image->width)
+                if (x + 1 < image->width)
                 {
                     out << std::endl;
                 }
@@ -156,13 +156,13 @@ std::istream& operator>>(std::istream& in, PGM_IO& ppm_io)
     }
     image->data.resize(image->width * image->height);
 
-    for (unsigned row = 0; row < image->height; ++row)
+    for (ULONG y = 0; y < image->height; ++y)
     {
-        for (unsigned column = 0; column < image->width; ++column)
+        for (ULONG x = 0; x < image->width; ++x)
         {
             try
             {
-                image->data[get_pixel_index(*image, {column, row})] =
+                image->data[get_pixel_index(*image, {x, y})] =
                     std::stoul(PGM_IO::read_pgm_instruction(in));
             }
             catch (std::invalid_argument&)

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -28,7 +28,7 @@
 #include <image.hpp>
 #include <pgm_io.hpp>
 
-BOOST_AUTO_TEST_SUITE(DisparityGraphTest)
+BOOST_AUTO_TEST_SUITE(ConstraintGraphTest)
 
 BOOST_AUTO_TEST_CASE(check_nodes_indexing)
 {

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -51,9 +51,9 @@ BOOST_AUTO_TEST_CASE(check_nodes_indexing)
 
     BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 0}, 0}), 0);
     BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 0}, 2}), 2);
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{1, 0}, 0}), 3);
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{1, 0}, 2}), 5);
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 1}, 0}), 6);
+    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 1}, 0}), 3);
+    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 1}, 2}), 5);
+    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{1, 0}, 0}), 6);
 }
 
 BOOST_AUTO_TEST_CASE(check_black_images)
@@ -134,14 +134,14 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 2}), 256 * 256, 1);
     BOOST_CHECK(!is_node_available(constraint_graph, {{0, 0}, 2}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 0, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{1, 0}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 0}), 0, 1);
+    BOOST_CHECK(is_node_available(constraint_graph, {{0, 1}, 0}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 1}), 129 * 129, 1);
-    BOOST_CHECK(!is_node_available(constraint_graph, {{1, 0}, 1}));
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 1}), 129 * 129, 1);
+    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 1}, 1}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 2}), 256 * 256, 1);
-    BOOST_CHECK(!is_node_available(constraint_graph, {{1, 0}, 2}));
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 2}), 256 * 256, 1);
+    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 1}, 2}));
 }
 
 BOOST_AUTO_TEST_CASE(check_disparity_loop)
@@ -224,8 +224,8 @@ BOOST_AUTO_TEST_CASE(check_minimal_node_value_calculation)
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 0.5, 1);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 2}, 0}), 1, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 2}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{2, 0}, 0}), 1, 1);
+    BOOST_CHECK(is_node_available(constraint_graph, {{2, 0}, 0}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -78,15 +78,15 @@ BOOST_AUTO_TEST_CASE(check_black_images)
 
     struct Node node{{0, 0}, 0};
     for (
-        node.pixel.column = 0;
-        node.pixel.column < disparity_graph.right.width;
-        ++node.pixel.column
+        node.pixel.x = 0;
+        node.pixel.x < disparity_graph.right.width;
+        ++node.pixel.x
     )
     {
         for (
-            node.pixel.row = 0;
-            node.pixel.row < disparity_graph.right.height;
-            ++node.pixel.row
+            node.pixel.y = 0;
+            node.pixel.y < disparity_graph.right.height;
+            ++node.pixel.y
         )
         {
             for (
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
             {
                 BOOST_CHECK_EQUAL(
                     is_node_available(constraint_graph, node),
-                    node.pixel.column + node.disparity
+                    node.pixel.x + node.disparity
                     < disparity_graph.left.width
                 );
             }

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -47,21 +47,21 @@ BOOST_AUTO_TEST_CASE(check_nodes_existence)
 
     for (ULONG row = 0; row < 2; ++row)
     {
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 2}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{0, row}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{1, row}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{2, row}, 0}));
 
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 0}, 1}));
-        BOOST_CHECK(node_exists(disparity_graph, {{row, 1}, 1}));
+        BOOST_CHECK(node_exists(disparity_graph, {{0, row}, 1}));
+        BOOST_CHECK(node_exists(disparity_graph, {{1, row}, 1}));
 
-        BOOST_CHECK(!node_exists(disparity_graph, {{row, 0}, 2}));
-        BOOST_CHECK(!node_exists(disparity_graph, {{row, 1}, 2}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{0, row}, 2}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{1, row}, 2}));
 
-        BOOST_CHECK(!node_exists(disparity_graph, {{row, 2}, 1}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{2, row}, 1}));
     }
-    BOOST_CHECK(!node_exists(disparity_graph, {{2, 0}, 0}));
-    BOOST_CHECK(!node_exists(disparity_graph, {{0, 3}, 2}));
-    BOOST_CHECK(!node_exists(disparity_graph, {{2, 3}, 2}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{0, 2}, 0}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{3, 0}, 2}));
+    BOOST_CHECK(!node_exists(disparity_graph, {{3, 2}, 2}));
 }
 
 BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
@@ -82,20 +82,20 @@ BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
     struct DisparityGraph disparity_graph{image, image, 3};
 
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 0), 0);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 0}, 0), 1);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 0), 1);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 1}, 0), 2);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 2}, 0), 4);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 2}, 0), 5);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 2}, 0), 5);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 1), 6);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 0}, 1), 7);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 1), 7);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 1}, 1), 8);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 1}, 1), 9);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 1}, 1), 9);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 2}, 1), 10);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 2}, 1), 11);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 2}, 1), 11);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 2), 12);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 3), 18);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 2}, 3), 23);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 0), 24);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 2}, 3), 23);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 0}, 0), 24);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 1}, 2}, 3), 47);
 }
 
@@ -127,22 +127,22 @@ BOOST_AUTO_TEST_CASE(check_neighborhood)
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {0, 1}));
     BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {1, 0}));
+    BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {0, 1}));
 
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 1}, {0, 2}));
+    BOOST_CHECK(neighborhood_exists(disparity_graph, {1, 0}, {2, 0}));
 
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 1}, {0, 0}));
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 1}, {1, 1}));
+    BOOST_CHECK(neighborhood_exists(disparity_graph, {1, 0}, {0, 0}));
+    BOOST_CHECK(neighborhood_exists(disparity_graph, {1, 0}, {1, 1}));
 
     BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {0, 0}));
     BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {1, 1}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {2, 0}));
     BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {0, 2}));
+    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {2, 0}));
 
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 1}, {0, 1}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 1}, {1, 0}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 1}, {1, 2}));
+    BOOST_CHECK(!neighborhood_exists(disparity_graph, {1, 0}, {1, 0}));
+    BOOST_CHECK(!neighborhood_exists(disparity_graph, {1, 0}, {0, 1}));
+    BOOST_CHECK(!neighborhood_exists(disparity_graph, {1, 0}, {2, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(check_edges_existence)
@@ -173,17 +173,17 @@ BOOST_AUTO_TEST_CASE(check_edges_existence)
 
     struct DisparityGraph disparity_graph{left_image, right_image, 2};
 
-    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 0}}));
-    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 1}}));
+    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}));
+    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}));
 
-    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 1}, 0}, {{0, 0}, 0}}));
-    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 1}, 1}, {{0, 0}, 0}}));
+    BOOST_CHECK(edge_exists(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 0}}));
+    BOOST_CHECK(edge_exists(disparity_graph, {{{1, 0}, 1}, {{0, 0}, 0}}));
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 1}, 2}, {{0, 1}, 1}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 1}, {{0, 1}, 2}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 2}, {{1, 0}, 1}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 1}, {{1, 0}, 2}}));
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{0, 1}, 0}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 1}, 0}, {{0, 1}, 2}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 0}, {{1, 0}, 2}}));
 }
 
 BOOST_AUTO_TEST_CASE(check_continuity_constraint)
@@ -214,11 +214,11 @@ BOOST_AUTO_TEST_CASE(check_continuity_constraint)
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{0, 1}, 0}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 1}, 0}, {{0, 0}, 2}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 2}}));
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 2}, {{1, 1}, 0}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 1}, 0}, {{1, 0}, 2}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 1}, 2}, {{1, 1}, 0}}));
+    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 1}, 0}, {{0, 1}, 2}}));
 }
 
 BOOST_AUTO_TEST_CASE(check_initial_edges_penalties)
@@ -250,34 +250,34 @@ BOOST_AUTO_TEST_CASE(check_initial_edges_penalties)
     struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 0}}),
+        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
         0.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}),
+        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 1}}),
         1.0,
         0.5
     );
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 1}, 1}, {{0, 2}, 0}}),
+        edge_penalty(disparity_graph, {{{1, 0}, 1}, {{2, 0}, 0}}),
         1.0,
         0.5
     );
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 1}, 0}, {{0, 0}, 2}}),
+        edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 2}}),
         4.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 1}, 2}, {{1, 0}, 0}}),
+        edge_penalty(disparity_graph, {{{1, 0}, 2}, {{0, 1}, 0}}),
         4.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 1}, 2}, {{1, 1}, 2}}),
+        edge_penalty(disparity_graph, {{{1, 0}, 2}, {{1, 1}, 2}}),
         0.0,
         0.5
     );
@@ -315,19 +315,19 @@ BOOST_AUTO_TEST_CASE(check_initial_nodes_penalties)
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0.0, 0.5);
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 2}), 1.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 0}), 1.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 1}), 4.0, 0.5);
-
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 2}, 0}), 0.0, 0.5);
-
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 1.0, 0.5);
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 1}), 4.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 2}), 1.0, 0.5);
+
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{2, 0}, 0}), 0.0, 0.5);
+
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 0}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 1}), 4.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 2}), 1.0, 0.5);
 
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 1}, 0}), 0.0, 0.5);
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 1}, 1}), 1.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 2}, 0}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{2, 1}, 0}), 0.0, 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(check_edges_penalties)
@@ -359,27 +359,27 @@ BOOST_AUTO_TEST_CASE(check_edges_penalties)
     struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 0}, 0}, {0, 1})
+        reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})
     ] = -2.0;
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 0}}),
+        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
         -2.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 1}}),
+        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}),
         -1.0,
         0.5
     );
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 1}, 0}, {{0, 0}, 0}}),
+        edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 0}}),
         -2.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 1}, 0}, {{0, 0}, 1}}),
+        edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 1}}),
         1.0,
         0.5
     );
@@ -414,13 +414,13 @@ BOOST_AUTO_TEST_CASE(check_nodes_penalties)
     struct DisparityGraph disparity_graph{left_image, right_image, 3};
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 0}, 0}, {0, 1})
+        reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})
     ] = -2.0;
 
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 3.0, 0.5);
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 0}), 1.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 1.0, 0.5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -45,19 +45,19 @@ BOOST_AUTO_TEST_CASE(check_nodes_existence)
     struct Image image{*pgm_io.get_image()};
     struct DisparityGraph disparity_graph{image, image, 2};
 
-    for (ULONG row = 0; row < 2; ++row)
+    for (ULONG y = 0; y < 2; ++y)
     {
-        BOOST_CHECK(node_exists(disparity_graph, {{0, row}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{1, row}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{2, row}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{0, y}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{1, y}, 0}));
+        BOOST_CHECK(node_exists(disparity_graph, {{2, y}, 0}));
 
-        BOOST_CHECK(node_exists(disparity_graph, {{0, row}, 1}));
-        BOOST_CHECK(node_exists(disparity_graph, {{1, row}, 1}));
+        BOOST_CHECK(node_exists(disparity_graph, {{0, y}, 1}));
+        BOOST_CHECK(node_exists(disparity_graph, {{1, y}, 1}));
 
-        BOOST_CHECK(!node_exists(disparity_graph, {{0, row}, 2}));
-        BOOST_CHECK(!node_exists(disparity_graph, {{1, row}, 2}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{0, y}, 2}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{1, y}, 2}));
 
-        BOOST_CHECK(!node_exists(disparity_graph, {{2, row}, 1}));
+        BOOST_CHECK(!node_exists(disparity_graph, {{2, y}, 1}));
     }
     BOOST_CHECK(!node_exists(disparity_graph, {{0, 2}, 0}));
     BOOST_CHECK(!node_exists(disparity_graph, {{3, 0}, 2}));

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -66,11 +66,11 @@ BOOST_AUTO_TEST_CASE(check_get_pixel_index)
     BOOST_CHECK_EQUAL(image.width, 3);
     BOOST_CHECK_EQUAL(image.height, 2);
     BOOST_CHECK_EQUAL(get_pixel_index(image, {0, 0}), 0);
-    BOOST_CHECK_EQUAL(get_pixel_index(image, {0, 1}), 1);
-    BOOST_CHECK_EQUAL(get_pixel_index(image, {0, 2}), 2);
-    BOOST_CHECK_EQUAL(get_pixel_index(image, {1, 0}), 3);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {1, 0}), 1);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {2, 0}), 2);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {0, 1}), 3);
     BOOST_CHECK_EQUAL(get_pixel_index(image, {1, 1}), 4);
-    BOOST_CHECK_EQUAL(get_pixel_index(image, {1, 2}), 5);
+    BOOST_CHECK_EQUAL(get_pixel_index(image, {2, 1}), 5);
 }
 
 BOOST_AUTO_TEST_CASE(check_get_pixel_value)
@@ -80,11 +80,11 @@ BOOST_AUTO_TEST_CASE(check_get_pixel_value)
     BOOST_CHECK_EQUAL(image.width, 3);
     BOOST_CHECK_EQUAL(image.height, 2);
     BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 0}), 5);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 1}), 4);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 2}), 3);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 0}), 2);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 0}), 4);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {2, 0}), 3);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 1}), 2);
     BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 1}), 1);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 2}), 0);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {2, 1}), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -57,11 +57,11 @@ BOOST_AUTO_TEST_CASE(read_image)
 
     struct Image image{*pgm_io.get_image()};
     BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 0}), 0);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 1}), 1);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 2}), 2);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 0}), 3);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 0}), 1);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {2, 0}), 2);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {0, 1}), 3);
     BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 1}), 4);
-    BOOST_CHECK_EQUAL(get_pixel_value(image, {1, 2}), 5);
+    BOOST_CHECK_EQUAL(get_pixel_value(image, {2, 1}), 5);
 }
 
 BOOST_AUTO_TEST_CASE(read_blank_file)


### PR DESCRIPTION
It should not have been easy, but looks like it has.
I'm confused with all these `rows` and `columns`,
because I imagine `row` as something horizontal,
but number of a row is a `y` coordinate.
I've tired of this, so I replace `row` by `y` and `column` by `x`.

Also, `<y, x>` order is not really natural,
so let's swap them.
This part is the most difficult,
because one error here may lead to very bad results in a future.
Let's risk for the beauty's sake!