### PR TITLE
Close #70: Add ability to use weights for edge and vertex penalty 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,8 @@ Added
   - ``right`` image
     (made on a camera located to the right of the ``left`` image),
   - ``disparity_levels`` is the number of different disparity levels
+  - ``cleanness`` weight of ``Node`` penalty.
+  - ``smoothness`` weight of ``Edge`` penalty.
     (the more it is, the more memory the graph consumes),
   - ``reparametrization`` that allows to solve the dual problem.
 

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -100,6 +100,16 @@ const ULONG NEIGHBORS_COUNT = 4;
  *  i_L = \left\langle i_R^x + k_{i_R}, i_R^y \right\rangle.
  * \f]
  *
+ * Color scales may be different,
+ * as well as noise level of images.
+ * Weight \f$\alpha\f$ (DisparityGraph::cleanness)
+ * allows to control these factors.
+ *
+ * Observed scene may be smooth or sharp.
+ * Also, it may be inconvenient to use \f$\alpha\f$ parameter
+ * because it needs to be too small or too high.
+ * \f$\beta\f$ weight (DisparityGraph::smoothness) serves in this case.
+ *
  * Set of all neighbors of a pixel will be noted \f$\mathcal{N}_i\f$.
  * Set with right and buttom neighbors
  * will be noted \f$N_i\f$.
@@ -114,19 +124,19 @@ const ULONG NEIGHBORS_COUNT = 4;
  *
  * \f[
  *  E\left( k \right) =
- *  \sum\limits_{i \in I} \left\|
+ *  \sum\limits_{i \in I} \alpha \cdot \left\|
  *      R\left( i^x, i^y \right)
  *      - L\left( i^x + k_i, i^y \right)
  *  \right\|^p
  *  + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
- *      \left\| k_i - k_j \right\|^p
+ *      \beta \cdot \left\| k_i - k_j \right\|^p.
  * \f]
  *
  * Denoting vertex penalty
  *
  * \f[
  *  q_i\left( d \right)
- *  = \left\|
+ *  = \alpha \cdot \left\|
  *        R\left( i^x, i^y \right) - L\left( i^x + d, i^y \right)
  *    \right\|^p
  * \f]
@@ -135,7 +145,7 @@ const ULONG NEIGHBORS_COUNT = 4;
  *
  * \f[
  *  g_{ij}\left( d, d' \right)
- *  = \left\| d - d' \right\|^p,
+ *  = \beta \cdot \left\| d - d' \right\|^p,
  * \f]
  *
  * it's needed to solve
@@ -363,13 +373,36 @@ struct DisparityGraph
      */
     FLOAT_ARRAY reparametrization;
     /**
+     * \brief Weight of difference in colors
+     * between pixel and its neighbor.
+     * Noted ad \f$\alpha\f$ in problem description.
+     *
+     * Heigher value means that the image is clean
+     * and you trust its color information
+     * in a sense that one vertex of displayed object
+     * has the same color from both images.
+     * The weight is opposite to DisparityGraph::smoothness.
+     */
+    FLOAT cleanness;
+    /**
+     * \brief Weight of difference between disparities of neighboring nodes.
+     * Noted ad \f$\beta\f$ in problem description.
+     *
+     * Heigher value means that the surface you observe
+     * tends to be smooth rather than sharp.
+     * The weight is opposite to DisparityGraph::cleanness.
+     */
+    FLOAT smoothness;
+    /**
      * \brief Create DisparityGraph entity
      * and initialize its DisparityGraph::reparametrization.
      */
     DisparityGraph(
         struct Image left,
         struct Image right,
-        ULONG disparity_levels
+        ULONG disparity_levels,
+        FLOAT cleanness,
+        FLOAT smoothness
     );
 };
 

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -69,14 +69,14 @@ const ULONG NEIGHBORS_COUNT = 4;
  * One element of the index set \f$I\f$ can be written as
  *
  * \f[
- *  I \ni i = \left\langle i^x, i^y \right\rangle
+ *  I \ni i = \left\langle i^x, i^y \right\rangle.
  * \f]
  *
  * We can represent images as mappings
  *
  * \f[
- *  L: I \rightarrow C \\
- *  R: I \rightarrow C \\
+ *  L: I \rightarrow C, \\
+ *  R: I \rightarrow C. \\
  * \f]
  *
  * Disparity is a difference
@@ -88,7 +88,7 @@ const ULONG NEIGHBORS_COUNT = 4;
  * correspondence function is called labeling and its signature is
  *
  * \f[
- *  k: I \rightarrow D
+ *  k: I \rightarrow D.
  * \f]
  *
  * Thus, given an index \f$i_R\f$ of a pixel on the right image
@@ -97,7 +97,7 @@ const ULONG NEIGHBORS_COUNT = 4;
  * by the formula
  *
  * \f[
- *  i_L = \left\langle i_R^x + k_{i_R}, i_R^y \right\rangle
+ *  i_L = \left\langle i_R^x + k_{i_R}, i_R^y \right\rangle.
  * \f]
  *
  * Set of all neighbors of a pixel will be noted \f$\mathcal{N}_i\f$.
@@ -155,40 +155,16 @@ const ULONG NEIGHBORS_COUNT = 4;
  * \f[
  *  \min\limits_{k: I \rightarrow D}{E\left( k \right)}
  *  = \min\limits_{k: I \rightarrow D}{\left\{
- *      \sum\limits_{i \in I} \left\|
- *          R\left( i^x, i^y \right)
- *          - L\left( i^x + k_i, i^y \right)
- *      \right\|^p
+ *      \sum\limits_{i \in I} q_i\left( k_i \right)
  *      + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
- *          \left\| k_i - k_j \right\|^p
+ *          g_{ij}\left( k_i, k_j \right)
  *  \right\}}
  *  \ge \sum\limits_{i \in I} \min\limits_{d \in D}{
- *  \left\|
- *      R\left( i^x, i^y \right)
- *      - L\left( i^x + d, i^y \right)
- *  \right\|^p}
+ *      q_i\left( d \right)
+ *  }
  *  + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
- *      \min\limits_{d, d' \in D}{\left\| d - d' \right\|^p}
- * \f]
- *
- * The last sum is zero, so
- *
- * \f[
- *  \min\limits_{k: I \rightarrow D}{E\left( k \right)}
- *  = \min\limits_{k: I \rightarrow D}{\left\{
- *      \sum\limits_{i \in I} \left\|
- *          R\left( i^x, i^y \right)
- *          - L\left( i^x + k_i, i^y \right)
- *      \right\|^p
- *      + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
- *          \left\| k_i - k_j \right\|^p
- *  \right\}}
- *  \ge \sum\limits_{i \in I} \min\limits_{d \in D}{
- *  \left\|
- *      R\left( i^x, i^y \right)
- *      - L\left( i^x + d, i^y \right)
- *  \right\|^p}
- *  = \widetilde{E}
+ *      \min\limits_{d, d' \in D}{g_{ij}\left( d, d' \right)}
+ *  = \widetilde{E}.
  * \f]
  *
  * Thus, \f$\widetilde{E}\f$ is a lower bound for the \f$E\f$.
@@ -199,7 +175,7 @@ const ULONG NEIGHBORS_COUNT = 4;
  * (DisparityGraph::reparametrization)
  *
  * \f[
- *  \varphi: I^2 \times K \rightarrow \mathbb{R}
+ *  \varphi: I^2 \times K \rightarrow \mathbb{R}.
  * \f]
  *
  * Let's introduce reparametrized energy function
@@ -207,39 +183,36 @@ const ULONG NEIGHBORS_COUNT = 4;
  * \f[
  *  E\left( k; \varphi \right)
  *      = \sum\limits_{i \in I} \left[
- *          \left\|
- *              R\left( i^x, i^y \right) - L\left( i^x + k_i, i^y \right)
- *          \right\|^p
+ *          q_i\left( k_i \right)
  *          + \sum\limits_{j \in \mathcal{N}_i}
  *              \varphi_{i j}\left( k_i \right)
  *      \right]
  *      + \sum\limits_{i \in I} \sum\limits_{j \in N_i} \left[
- *          \left\| k_i - k_j \right\|^p
+ *          g_{ij}\left( k_i, k_j \right)
  *          - \varphi_{i j}\left( k_i \right)
  *          - \varphi_{j i}\left( k_j \right)
  *      \right]
  *  = E\left( k \right),
- *  \quad \forall \varphi: I^2 \times K \rightarrow \mathbb{R}
+ *  \quad \forall \varphi: I^2 \times K \rightarrow \mathbb{R},
  * \f]
  *
- * Though, the lower boundary of reparametrized energy may change
+ * On the other hand,
+ * the lower boundary of the reparametrized energy may change
  *
  * \f[
  *  \widetilde{E}\left( \varphi \right)
  *      = \sum\limits_{i \in I} \min_{d \in D}{\left[
- *          \left\|
- *              R\left( i^x, i^y \right) - L\left( i^x + d, i^y \right)
- *          \right\|^p
+ *          q_i\left( d \right)
  *          + \sum\limits_{j \in \mathcal{N}_i}
  *              \varphi_{i j}\left( d \right)
  *      \right]}
  *      + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
  *          \min_{d, d' \in D}{\left[
- *              \left\| d - d' \right\|^p
+ *              g_{ij}\left( d, d' \right)
  *              - \varphi_{i j}\left( d \right)
  *              - \varphi_{j i}\left( d' \right)
  *          \right]}
- *  \neq \widetilde{E}
+ *  \neq \widetilde{E}.
  * \f]
  *
  * If we will increase the lower boundary
@@ -259,19 +232,17 @@ const ULONG NEIGHBORS_COUNT = 4;
  *
  * \f[
  *  \sum\limits_{i \in I} \min_{d \in D}{\left[
- *      \left\|
- *          R\left( i^x, i^y \right) - L\left( i^x + d, i^y \right)
- *      \right\|^p
+ *      q_i\left( d \right)
  *      + \sum\limits_{j \in \mathcal{N}_i}
  *          \varphi_{i j}\left( d \right)
  *  \right]}
  *  + \sum\limits_{i \in I} \sum\limits_{j \in N_i}
  *      \min_{d, d' \in D}{\left[
- *          \left\| d - d' \right\|^p
+ *          g_{ij}\left( d, d' \right)
  *          - \varphi_{i j}\left( d \right)
  *          - \varphi_{j i}\left( d' \right)
  *      \right]}
- *  \to \max_{\varphi: I^2 \times K \rightarrow \mathbb{R}}
+ *  \to \max_{\varphi: I^2 \times K \rightarrow \mathbb{R}}.
  * \f]
  *
  * Introducing reparametrized vertex penalty

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -333,8 +333,8 @@ FLOAT edge_penalty(const struct DisparityGraph& graph, struct Edge edge)
     return
         graph.smoothness
         * SQR(TO_FLOAT(edge.node.disparity) - TO_FLOAT(edge.neighbor.disparity))
-        + reparametrization_value_slow(graph, edge)
-        + reparametrization_value(graph, edge.neighbor, edge.node.pixel);
+        - reparametrization_value_slow(graph, edge)
+        - reparametrization_value(graph, edge.neighbor, edge.node.pixel);
 }
 
 FLOAT node_penalty(const struct DisparityGraph& graph, struct Node node)
@@ -345,8 +345,8 @@ FLOAT node_penalty(const struct DisparityGraph& graph, struct Node node)
         graph.cleanness
         * SQR(TO_FLOAT(get_pixel_value(graph.right, node.pixel))
             - TO_FLOAT(get_pixel_value(graph.left, left_pixel)))
-        - reparametrization_value_fast(graph, node, 0)
-        - reparametrization_value_fast(graph, node, 1)
-        - reparametrization_value_fast(graph, node, 2)
-        - reparametrization_value_fast(graph, node, 3);
+        + reparametrization_value_fast(graph, node, 0)
+        + reparametrization_value_fast(graph, node, 1)
+        + reparametrization_value_fast(graph, node, 2)
+        + reparametrization_value_fast(graph, node, 3);
 }

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -331,7 +331,8 @@ FLOAT reparametrization_value_fast(
 FLOAT edge_penalty(const struct DisparityGraph& graph, struct Edge edge)
 {
     return
-        SQR(TO_FLOAT(edge.node.disparity) - TO_FLOAT(edge.neighbor.disparity))
+        graph.smoothness
+        * SQR(TO_FLOAT(edge.node.disparity) - TO_FLOAT(edge.neighbor.disparity))
         + reparametrization_value_slow(graph, edge)
         + reparametrization_value(graph, edge.neighbor, edge.node.pixel);
 }
@@ -341,7 +342,8 @@ FLOAT node_penalty(const struct DisparityGraph& graph, struct Node node)
     Pixel left_pixel = node.pixel;
     left_pixel.x += node.disparity;
     return
-        SQR(TO_FLOAT(get_pixel_value(graph.right, node.pixel))
+        graph.cleanness
+        * SQR(TO_FLOAT(get_pixel_value(graph.right, node.pixel))
             - TO_FLOAT(get_pixel_value(graph.left, left_pixel)))
         - reparametrization_value_fast(graph, node, 0)
         - reparametrization_value_fast(graph, node, 1)

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -23,6 +23,7 @@
  */
 #include <disparity_graph.hpp>
 
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -32,11 +33,15 @@
 DisparityGraph::DisparityGraph(
     struct Image left,
     struct Image right,
-    ULONG disparity_levels
+    ULONG disparity_levels,
+    FLOAT cleanness,
+    FLOAT smoothness
 )
     : left{std::move(left)}
     , right{std::move(right)}
     , disparity_levels{disparity_levels}
+    , cleanness{cleanness}
+    , smoothness{smoothness}
 {
     if (!image_valid(this->left))
     {
@@ -95,6 +100,39 @@ DisparityGraph::DisparityGraph(
             + " and "
             + std::to_string(this->right.max_value)
             + "respectively."
+        );
+    }
+    if (this->cleanness < 0)
+    {
+        throw std::invalid_argument(
+            "Cleanness weight should not be negative. "
+            "Actual value is "
+            + std::to_string(this->cleanness)
+            + "."
+        );
+    }
+    if (this->smoothness < 0)
+    {
+        throw std::invalid_argument(
+            "Smoothness weight should not be negative. "
+            "Actual value is "
+            + std::to_string(this->smoothness)
+            + "."
+        );
+    }
+    if (
+        this->cleanness < std::numeric_limits<FLOAT>::epsilon()
+        && this->smoothness < std::numeric_limits<FLOAT>::epsilon()
+    )
+    {
+        throw std::invalid_argument(
+            "Either cleanness or smoothness, or both, "
+            "should be creater than zero. "
+            "You've provided smoothness "
+            + std::to_string(this->smoothness)
+            + " and cleanness "
+            + std::to_string(this->cleanness)
+            + "."
         );
     }
 

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -25,7 +25,14 @@ int main(int argc, char* argv[]) try
          "Right image")
         ("disparity-levels,d",
          boost::program_options::value<std::string>(),
-         "Number of disparity levels");
+         "Number of disparity levels")
+        ("smoothness,s",
+         boost::program_options::value<std::string>(),
+         "Smoothness weight")
+        ("cleanness,c",
+         boost::program_options::value<std::string>(),
+         "Cleanness weight")
+    ;
 
     boost::program_options::variables_map vm;
     try
@@ -66,10 +73,26 @@ int main(int argc, char* argv[]) try
                     vm["disparity-levels"].as<std::string>()
                 );
             }
+            FLOAT cleanness = 1;
+            if (vm.count("cleanness") == 1)
+            {
+                cleanness = std::stoul(
+                    vm["cleanness"].as<std::string>()
+                );
+            }
+            FLOAT smoothness = 1;
+            if (vm.count("smoothness") == 1)
+            {
+                smoothness = std::stoul(
+                    vm["smoothness"].as<std::string>()
+                );
+            }
             struct DisparityGraph disparity_graph{
                 left_image,
                 right_image,
-                disparity_levels
+                disparity_levels,
+                cleanness,
+                smoothness
             };
         }
         catch (std::invalid_argument& e)

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(check_nodes_indexing)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{image, image, 3};
+    struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 1)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
 
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{image, image, 3};
+    struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 1)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 1, 1);
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{image, image, 3};
+    struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 128 * 128)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 128 * 128, 1);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(check_disparity_loop)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 2, 1, 1};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 15)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 15, 1);
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(check_minimal_node_value_calculation)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
     struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 0.5)};
     BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 0.5, 1);

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -356,32 +356,32 @@ BOOST_AUTO_TEST_CASE(check_edges_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 10};
 
     disparity_graph.reparametrization[
         reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})
-    ] = -2.0;
+    ] = -2;
 
     BOOST_CHECK_CLOSE(
         edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
-        -2.0,
-        0.5
+        2,
+        1
     );
     BOOST_CHECK_CLOSE(
         edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}),
-        -1.0,
-        0.5
+        12,
+        1
     );
 
     BOOST_CHECK_CLOSE(
         edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 0}}),
-        -2.0,
-        0.5
+        2,
+        1
     );
     BOOST_CHECK_CLOSE(
         edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 1}}),
-        1.0,
-        0.5
+        10,
+        1
     );
 }
 
@@ -411,16 +411,16 @@ BOOST_AUTO_TEST_CASE(check_nodes_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 10, 1};
 
     disparity_graph.reparametrization[
         reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})
-    ] = -2.0;
+    ] = -2;
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 3.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 8, 1);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0, 1);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 1.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 10, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(check_nodes_existence)
     image_content >> pgm_io;
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
-    struct DisparityGraph disparity_graph{image, image, 2};
+    struct DisparityGraph disparity_graph{image, image, 2, 1, 1};
 
     for (ULONG y = 0; y < 2; ++y)
     {
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{image, image, 3};
+    struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
 
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 0), 0);
     BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 0), 1);
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(check_neighborhood)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {1, 0}));
     BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {0, 1}));
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(check_edges_existence)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 2};
+    struct DisparityGraph disparity_graph{left_image, right_image, 2, 1, 1};
 
     BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}));
     BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}));
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(check_continuity_constraint)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
     BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 2}}));
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(check_initial_edges_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     BOOST_CHECK_CLOSE(
         edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(check_initial_nodes_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 1.0, 0.5);
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0.0, 0.5);
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(check_edges_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     disparity_graph.reparametrization[
         reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(check_nodes_penalties)
     BOOST_REQUIRE(pgm_io.get_image());
     struct Image right_image{*pgm_io.get_image()};
 
-    struct DisparityGraph disparity_graph{left_image, right_image, 3};
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     disparity_graph.reparametrization[
         reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})


### PR DESCRIPTION
Implement cleanness and smoothness weights
==========================================

The weights allow to control regularization
and take noisiness of provided images into account
as well as smoothness of observed scene.

Introduce the terms in constructor and main application.
Calculation of weights will be done in the next commit.

I should admit that the weights does **not** affect
corresponding reparametrization values.
They're applied only to original penalties.

Fix reparametrization usage
===========================

Oh snap.
It's appeared that in documentation we
subtract reparametrization from edges and add them to nodes,
but in code we're doing vice versa `//_o`.

Refactor documentation
======================

- Add forgotten commas and dots after formulas of disparity graph.
- Use `q` and `g` shortcuts to node and edge penalty
  to shorten formulas of disparity graph.