### PR TITLE
Fix #84: Vertical lowest penalty uses horizontal constraints for vertical neighbors

### DIFF
--- a/lib/lowest_penalties.cpp
+++ b/lib/lowest_penalties.cpp
@@ -168,7 +168,9 @@ FLOAT calculate_lowest_neighborhood_penalty_fast(
         ++edge.node.disparity
     )
     {
-        ULONG initial_disparity = edge.node.disparity <= 1
+        ULONG initial_disparity =
+            edge.node.disparity <= 1
+                || edge.neighbor.pixel.x == edge.node.pixel.x
             ? 0
             : edge.node.disparity - 1;
         for (

--- a/lib/lowest_penalties.cpp
+++ b/lib/lowest_penalties.cpp
@@ -161,6 +161,7 @@ FLOAT calculate_lowest_neighborhood_penalty_fast(
 )
 {
     FLOAT minimal_penalty = edge_penalty(graph, edge);
+    ULONG initial_disparity = 0;
     for (
         edge.node.disparity = 0;
         edge.node.pixel.x + edge.node.disparity < graph.left.width
@@ -168,11 +169,17 @@ FLOAT calculate_lowest_neighborhood_penalty_fast(
         ++edge.node.disparity
     )
     {
-        ULONG initial_disparity =
+        if (
             edge.node.disparity <= 1
-                || edge.neighbor.pixel.x == edge.node.pixel.x
-            ? 0
-            : edge.node.disparity - 1;
+            || edge.neighbor.pixel.x == edge.node.pixel.x
+        )
+        {
+            initial_disparity = 0;
+        }
+        else
+        {
+            initial_disparity = edge.node.disparity - 1;
+        }
         for (
             edge.neighbor.disparity = initial_disparity;
             edge.neighbor.pixel.x + edge.neighbor.disparity < graph.left.width

--- a/tests/lowest_penalties.cpp
+++ b/tests/lowest_penalties.cpp
@@ -341,6 +341,63 @@ BOOST_AUTO_TEST_CASE(check_lowest_pixel_penalty)
     BOOST_CHECK_CLOSE(lowest_pixel_penalty(lowest_penalties, {2, 1}), 90, 1);
 }
 
+BOOST_AUTO_TEST_CASE(check_lowest_vertical_neighborhood_penalty)
+{
+    PGM_IO pgm_io;
+    std::istringstream left_image_content{R"image(
+    P2
+    3 2
+    4
+    0 0 0
+    0 0 0
+    )image"};
+    std::istringstream right_image_content{R"image(
+    P2
+    3 2
+    4
+    0 0 0
+    0 0 0
+    )image"};
+
+    left_image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image left_image{*pgm_io.get_image()};
+
+    right_image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image right_image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
+
+    disparity_graph.reparametrization[
+        reparametrization_index(disparity_graph, {{0, 0}, 0}, {0, 1})
+    ] = -5;
+    disparity_graph.reparametrization[
+        reparametrization_index(disparity_graph, {{0, 0}, 1}, {0, 1})
+    ] = -5;
+    disparity_graph.reparametrization[
+        reparametrization_index(disparity_graph, {{0, 0}, 2}, {0, 1})
+    ] = 0;
+
+    disparity_graph.reparametrization[
+        reparametrization_index(disparity_graph, {{0, 1}, 0}, {0, 0})
+    ] = 0;
+    disparity_graph.reparametrization[
+        reparametrization_index(disparity_graph, {{0, 1}, 1}, {0, 0})
+    ] = -5;
+    disparity_graph.reparametrization[
+        reparametrization_index(disparity_graph, {{0, 1}, 2}, {0, 0})
+    ] = -5;
+
+    struct LowestPenalties lowest_penalties{disparity_graph};
+
+    BOOST_CHECK_CLOSE(
+        lowest_neighborhood_penalty_fast(lowest_penalties, {0, 0}, {0, 1}),
+        4,
+        1
+    );
+}
+
 BOOST_AUTO_TEST_CASE(check_lowest_neighborhood_penalty)
 {
     PGM_IO pgm_io;


### PR DESCRIPTION
When I wanted to copy loop over neighbors for #21,
I've noticed that I use horizontal constraints
for all neighbors including vertical.
This was easy to fix, but a bit hard to check.