### PR TITLE
Close #21: Implement consistency check on constraint graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,8 @@ Added
   - ``neighbor`` is the end of the edge.
 
 - ``neighbor_index`` allows to get index of neighboring pixel for fast access.
+- ``neighbor_by_index`` allows to get a neighboring pixel
+  of the ``Node`` by index of the neighbor.
 - ``neighborhood_exists`` checks whether two pixels are really neighbors.
 - ``neighborhood_exists_fast`` checks whether a pixel has a neighbor
   with specified index.
@@ -84,6 +86,7 @@ Added
   after optimization of ``DisparityGraph``.
   Contains
 
+  - Constructor to build a ``ConstraintGraph`` given ``DisparityGraph``.
   - ``nodes_availability`` array that contains information about ability
     of each ``Node`` to be chosen,
   - ``disparity_graph`` constant pointer to ``DisparityGraph`` instance
@@ -92,12 +95,20 @@ Added
 
 - ``node_exists`` function to check whether specified ``Node``
   is marked as available in ``ConstraintGraph``.
-- ``make_node_available`` mark specified ``Node``
+- ``make_node_available`` to mark specified ``Node``
   as available in ``ConstraintGraph``.
-- ``make_node_unavailable`` mark specified ``Node``
+- ``make_node_unavailable`` to mark specified ``Node``
   as unavailable in ``ConstraintGraph``.
-- ``disparity2constraint`` function
-  to construct a ``ConstraintGraph`` given ``DisparityGraph``.
+- ``make_all_nodes_unavailable`` to mark all ``Node`` instances
+  as unavailable in ``ConstraintGraph``.
+- ``solve_csp`` to solve a CSP problem given ``ConstraintGraph``.
+- ``csp_solution_iteration`` to make a step in ``solve_csp``.
+- ``should_remove_node`` to check whether we need to remove the node.
+- ``is_edge_available`` to check edge existence.
+- ``is_node_available`` to check node existence.
+- ``node_index`` to get index of the node in ``nodes_availability`` array.
+- ``check_nodes_left`` to check whether there are nodes left
+  in ``ConstraintGraph``.
 
 - ``LowestPenalties`` to store minimal penalties of pixels and neighborhoods.
   Contains

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -393,5 +393,28 @@ BOOL should_remove_node(
     const struct ConstraintGraph& graph,
     struct Node node
 );
+/**
+ * \brief Perform one iteration of ::solve.
+ *
+ * @return
+ *  Boolean flag.
+ *  `true` if availability of one node was changed.
+ *  `false` if a solution was found (at least, an empty one)
+ *  and nothing was changed during iteration.
+ */
+BOOL solution_iteration(struct ConstraintGraph* graph);
+/**
+ * \brief Remove all nodes that don't belong to any soluton.
+ *
+ * @return
+ *  Boolean flag.
+ *  `true` if nonempty solution was found.
+ *  `false` if all nodes were removed --- the problem is unsolvable.
+ */
+BOOL solve(struct ConstraintGraph* graph);
+/**
+ * \brief Check whether at least one node is available.
+ */
+BOOL check_nodes_left(const struct ConstraintGraph& graph);
 
 #endif

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -393,7 +393,7 @@ BOOL should_remove_node(
     struct Node node
 );
 /**
- * \brief Perform one iteration of ::solve.
+ * \brief Perform one iteration of ::solve_csp.
  *
  * @return
  *  Boolean flag.
@@ -401,7 +401,7 @@ BOOL should_remove_node(
  *  `false` if a solution was found (at least, an empty one)
  *  and nothing was changed during iteration.
  */
-BOOL solution_iteration(struct ConstraintGraph* graph);
+BOOL csp_solution_iteration(struct ConstraintGraph* graph);
 /**
  * \brief Remove all nodes that don't belong to any soluton.
  *
@@ -410,7 +410,7 @@ BOOL solution_iteration(struct ConstraintGraph* graph);
  *  `true` if nonempty solution was found.
  *  `false` if all nodes were removed --- the problem is unsolvable.
  */
-BOOL solve(struct ConstraintGraph* graph);
+BOOL solve_csp(struct ConstraintGraph* graph);
 /**
  * \brief Check whether at least one node is available.
  */

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -265,7 +265,8 @@ struct ConstraintGraph
      * \brief DisparityGraph instance
      * for which the ConstraintGraph instance was created.
      */
-    const struct DisparityGraph* disparity_graph;
+    const struct DisparityGraph& disparity_graph;
+    const struct LowestPenalties& lowest_penalties;
     /**
      * \brief Array that contains markers for availability of nodes.
      *
@@ -294,6 +295,24 @@ struct ConstraintGraph
      * \f$\varepsilon\f$ in formulas of the class description.
      */
     FLOAT threshold;
+    /**
+     * \brief Build a CSP problem for given DisparityGraph.
+     *
+     * Corresponding ConstraintGraph should have
+     * the same amount of nodes as corresponding DisparityGraph.
+     *
+     * First, all nodes and edges assumed to be unavailable.
+     * Then, each Node that has a penalty that differs from the minimal
+     * less than by `threshold`, is marked as available one.
+     *
+     * To not recalculate lowest penalties,
+     * it's good to have precalculated LowestPenalties instance.
+     */
+    ConstraintGraph(
+        const struct DisparityGraph& disparity_graph,
+        const struct LowestPenalties& lowest_penalties,
+        FLOAT threshold
+    );
 };
 /**
  * \brief Get an index of ConstraintGraph::nodes_availability element
@@ -329,6 +348,8 @@ void make_node_unavailable(
 /**
  * \brief Check whether the Node is still available.
  *
+ * Takes value from ConstraintGraph::nodes_availability array.
+ *
  * The function doesn't check existence of the Node.
  * You should perform it by yourself
  * using ::node_exists.
@@ -336,20 +357,6 @@ void make_node_unavailable(
 BOOL is_node_available(
     const struct ConstraintGraph& graph,
     struct Node node
-);
-/**
- * \brief Build a CSP problem for given DisparityGraph.
- *
- * Corresponding ConstraintGraph should have
- * the same amount of nodes as corresponding DisparityGraph.
- *
- * First, all nodes and edges assumed to be unavailable.
- * Then, each Node that has a penalty that differs from the minimal
- * less than by `threshold`, is marked as available one.
- */
-struct ConstraintGraph disparity2constraint(
-    const struct DisparityGraph& disparity_graph,
-    FLOAT threshold
 );
 
 #endif

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -346,6 +346,10 @@ void make_node_unavailable(
     struct Node node
 );
 /**
+ * \brief Mark all nodes as unavailable.
+ */
+void make_all_nodes_unavailable(struct ConstraintGraph* graph);
+/**
  * \brief Check whether the Node is still available.
  *
  * Takes value from ConstraintGraph::nodes_availability array.

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -358,5 +358,36 @@ BOOL is_node_available(
     const struct ConstraintGraph& graph,
     struct Node node
 );
+/**
+ * \brief Check whether the Edge is still available.
+ *
+ * Compares penalty of the Edge with given ConstraintGraph::threshold
+ * and checks whether two nodes of the Edge are available
+ * using ConstraintGraph::is_node_available.
+ *
+ * The function doesn't check existence of the Edge.
+ * You should perform it by yourself
+ * using ::edge_exists.
+ */
+BOOL is_edge_available(
+    const struct ConstraintGraph& graph,
+    struct Edge edge
+);
+/**
+ * \brief Check whether the Node should be removed.
+ *
+ * If for each neighbor of the Node
+ * there exists at least one Edge that was not removed,
+ * the Node is still available.
+ * Otherwise, it should be marked as removed.
+ *
+ * The function doesn't check existence of the Node.
+ * You should perform it by yourself
+ * using ::node_exists.
+ */
+BOOL should_remove_node(
+    const struct ConstraintGraph& graph,
+    struct Node node
+);
 
 #endif

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -369,8 +369,7 @@ BOOL is_node_available(
  * and checks whether two nodes of the Edge are available
  * using ConstraintGraph::is_node_available.
  *
- * The function doesn't check existence of the Edge.
- * You should perform it by yourself
+ * The function checks existence of the Edge
  * using ::edge_exists.
  */
 BOOL is_edge_available(

--- a/include/lowest_penalties.hpp
+++ b/include/lowest_penalties.hpp
@@ -143,6 +143,16 @@ ULONG neighborhood_index_slow(
     struct Edge edge
 );
 /**
+ * \brief Get neighbor pixel to current one using neighbor index.
+ *
+ * Note that the function doesn't check existence of provided neighborhood.
+ * Use ::neighborhood_exists to make sure that you use it right.
+ */
+Pixel neighbor_by_index(
+    struct Pixel pixel,
+    ULONG neighbor_index
+);
+/**
  * \brief Calculate minimal penalty among nodes of a pixel.
  */
 FLOAT calculate_lowest_pixel_penalty(

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -222,7 +222,7 @@ BOOL check_nodes_left(const struct ConstraintGraph& graph)
     return false;
 }
 
-BOOL solution_iteration(struct ConstraintGraph* graph)
+BOOL csp_solution_iteration(struct ConstraintGraph* graph)
 {
     Node node{{0, 0}, 0};
     BOOL pixel_available = false;
@@ -281,9 +281,9 @@ BOOL solution_iteration(struct ConstraintGraph* graph)
     return changed;
 }
 
-BOOL solve(struct ConstraintGraph* graph)
+BOOL solve_csp(struct ConstraintGraph* graph)
 {
-    while (solution_iteration(graph))
+    while (csp_solution_iteration(graph))
     {
     }
     return check_nodes_left(*graph);

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -104,6 +104,21 @@ void make_node_unavailable(
         = false;
 }
 
+void make_all_nodes_unavailable(struct ConstraintGraph* graph)
+{
+    for (
+        ULONG index = 0;
+        index <
+            graph->disparity_graph.right.width
+            * graph->disparity_graph.right.height
+            * graph->disparity_graph.disparity_levels;
+        ++index
+    )
+    {
+        graph->nodes_availability[index] = false;
+    }
+}
+
 BOOL is_node_available(
     const struct ConstraintGraph& graph,
     struct Node node

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -114,3 +114,40 @@ BOOL is_node_available(
     ];
 }
 
+BOOL is_edge_available(
+    const struct ConstraintGraph& graph,
+    struct Edge edge
+)
+{
+    return
+        (edge_penalty(graph.disparity_graph, edge)
+         - lowest_neighborhood_penalty(graph.lowest_penalties, edge)
+         <= graph.threshold)
+        && is_node_available(graph, edge.node)
+        && is_node_available(graph, edge.neighbor);
+}
+
+BOOL should_remove_node(
+    const struct ConstraintGraph& graph,
+    struct Node node
+)
+{
+    Edge edge{node, node};
+    if (neighborhood_exists_fast(graph.disparity_graph, node.pixel, 0))
+    {
+        ULONG initial_disparity = edge.node.disparity <= 1
+            ? 0
+            : edge.node.disparity - 1;
+        for (
+            edge.neighbor.disparity = initial_disparity;
+            edge.neighbor.pixel.x + edge.neighbor.disparity
+                < graph.disparity_graph.left.width
+            && edge.neighbor.disparity
+                < graph.disparity_graph.disparity_levels;
+            ++edge.neighbor.disparity
+        )
+        {
+        }
+    }
+    return is_node_available(graph, node);
+}

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -139,7 +139,8 @@ BOOL is_edge_available(
          - lowest_neighborhood_penalty(graph.lowest_penalties, edge)
          <= graph.threshold)
         && is_node_available(graph, edge.node)
-        && is_node_available(graph, edge.neighbor);
+        && is_node_available(graph, edge.neighbor)
+        && edge_exists(graph.disparity_graph, edge);
 }
 
 BOOL should_remove_node(
@@ -188,7 +189,7 @@ BOOL should_remove_node(
             ++edge.neighbor.disparity
         )
         {
-            if (edge_exists(graph.disparity_graph, edge))
+            if (is_edge_available(graph, edge))
             {
                 edge_found = true;
                 break;

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -282,6 +282,8 @@ BOOL solution_iteration(struct ConstraintGraph* graph)
 
 BOOL solve(struct ConstraintGraph* graph)
 {
-    while (solution_iteration(graph));
+    while (solution_iteration(graph))
+    {
+    }
     return check_nodes_left(*graph);
 }

--- a/lib/lowest_penalties.cpp
+++ b/lib/lowest_penalties.cpp
@@ -121,6 +121,31 @@ ULONG neighborhood_index_slow(
     );
 }
 
+Pixel neighbor_by_index(
+    struct Pixel pixel,
+    ULONG neighbor_index
+)
+{
+    struct Pixel neighbor{pixel};
+    if (neighbor_index == 0)
+    {
+        ++neighbor.x;
+    }
+    else if (neighbor_index == 1)
+    {
+        --neighbor.x;
+    }
+    else if (neighbor_index == 2)
+    {
+        ++neighbor.y;
+    }
+    else if (neighbor_index == 3)
+    {
+        --neighbor.y;
+    }
+    return neighbor;
+}
+
 FLOAT calculate_lowest_pixel_penalty(
     const struct DisparityGraph& graph,
     struct Pixel pixel
@@ -193,26 +218,9 @@ FLOAT calculate_lowest_neighborhood_penalty_slow(
     ULONG neighbor_index
 )
 {
-    struct Pixel neighbor{pixel};
-    if (neighbor_index == 0)
-    {
-        ++neighbor.x;
-    }
-    else if (neighbor_index == 1)
-    {
-        --neighbor.x;
-    }
-    else if (neighbor_index == 2)
-    {
-        ++neighbor.y;
-    }
-    else if (neighbor_index == 3)
-    {
-        --neighbor.y;
-    }
     return calculate_lowest_neighborhood_penalty_fast(
         graph,
-        {{pixel, 0}, {neighbor, 0}}
+        {{pixel, 0}, {neighbor_by_index(pixel, neighbor_index), 0}}
     );
 }
 

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -26,6 +26,7 @@
 #include <constraint_graph.hpp>
 #include <disparity_graph.hpp>
 #include <image.hpp>
+#include <lowest_penalties.hpp>
 #include <pgm_io.hpp>
 
 BOOST_AUTO_TEST_SUITE(ConstraintGraphTest)
@@ -46,14 +47,14 @@ BOOST_AUTO_TEST_CASE(check_nodes_indexing)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 1)};
-    BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
+    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 1};
 
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 0}, 0}), 0);
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 0}, 2}), 2);
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 1}, 0}), 3);
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{0, 1}, 2}), 5);
-    BOOST_CHECK_EQUAL(node_index(*(constraint_graph.disparity_graph), {{1, 0}, 0}), 6);
+    BOOST_CHECK_EQUAL(node_index(constraint_graph.disparity_graph, {{0, 0}, 0}), 0);
+    BOOST_CHECK_EQUAL(node_index(constraint_graph.disparity_graph, {{0, 0}, 2}), 2);
+    BOOST_CHECK_EQUAL(node_index(constraint_graph.disparity_graph, {{0, 1}, 0}), 3);
+    BOOST_CHECK_EQUAL(node_index(constraint_graph.disparity_graph, {{0, 1}, 2}), 5);
+    BOOST_CHECK_EQUAL(node_index(constraint_graph.disparity_graph, {{1, 0}, 0}), 6);
 }
 
 BOOST_AUTO_TEST_CASE(check_black_images)
@@ -72,8 +73,8 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 1)};
-    BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
+    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 1};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 1, 1);
 
     struct Node node{{0, 0}, 0};
@@ -121,8 +122,8 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 128 * 128)};
-    BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
+    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 128 * 128};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 128 * 128, 1);
 
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 0, 1);
@@ -171,8 +172,8 @@ BOOST_AUTO_TEST_CASE(check_disparity_loop)
     struct Image right_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, right_image, 2, 1, 1};
-    struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 15)};
-    BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
+    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 15};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 15, 1);
 
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 4, 1);
@@ -220,8 +221,8 @@ BOOST_AUTO_TEST_CASE(check_minimal_node_value_calculation)
     struct Image right_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
-    struct ConstraintGraph constraint_graph{disparity2constraint(disparity_graph, 0.5)};
-    BOOST_REQUIRE_EQUAL(constraint_graph.disparity_graph, &disparity_graph);
+    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 0.5};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 0.5, 1);
 
     BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{2, 0}, 0}), 1, 1);


### PR DESCRIPTION
# Changes

New functionality is described in CHANGELOG.

Move `disparity2constraint` functionality to constraint graph constructor,
because it's more natural to make construction in the constructor
The constructor is not assumed to be parallel,
so it can be created and used only on CPU with C++.

Fix `readability-braces-around-statements`.
The error
https://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html
requires bodies of statements and loops to be inside braces.
Okay, will make a blank one.

# Feelings

It was a very long pause again.
I worked on a scientific article.
I guess, now I'm relatively free and can do at least naive solver soon.