### PR TITLE
Fix #87: True negatives for node availability check in constraint graph

### DIFF
--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -175,9 +175,17 @@ BOOL should_remove_node(
         }
 
         edge.neighbor.pixel = neighbor_by_index(node.pixel, neighbor_index);
-        initial_disparity = edge.node.disparity <= 1
-            ? 0
-            : edge.node.disparity - 1;
+        if (
+            edge.node.pixel.x + 1 == edge.neighbor.pixel.x
+            && edge.node.disparity > 1
+        )
+        {
+            initial_disparity = edge.node.disparity - 1;
+        }
+        else
+        {
+            initial_disparity = 0;
+        }
 
         edge_found = false;
         for (


### PR DESCRIPTION
I have found this bug during working on task #22.
The algorithm removed all nodes,
but theoretically, it should not do this.
Then, I've investigated the problem,
and found out that I apply smoothness constraints
for horizontal and vertical edges.
It was not easy to find, easy to fix, and not very easy to reproduce.