### PR TITLE
Close #22: Calculate disparity map by naive algorithm

### DIFF
--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -32,6 +32,8 @@
 #include <algorithm>
 #include <vector>
 
+#define MAX(x, y) ((x) >= (y)? (x) : (y))
+
 /**
  * \brief Floating point type alias.
  * to use the same name on CPU and GPU.

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -137,5 +137,16 @@ struct ConstraintGraph* choose_best_node(
  * will be minimal.
  */
 struct ConstraintGraph* find_labeling(struct ConstraintGraph* graph);
+/**
+ * \brief Build a disparity map by the constraint graph.
+ *
+ * For each pixel of the graph
+ * find the available disparity
+ * and add it as the pixel's intensity
+ * to the output image.
+ */
+struct Image build_disparity_map(
+    const struct ConstraintGraph& constraint_graph
+);
 
 #endif

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -29,28 +29,113 @@
 
 #include <lowest_penalties.hpp>
 
+/**
+ * \brief Construct an array of available differences
+ * between penalties of nodes of the pixel
+ * with the lowest penalty in the pixel.
+ * The output is sorted in ascending order.
+ */
 FLOAT_ARRAY fetch_pixel_available_penalties(
     const DisparityGraph& graph,
     struct Pixel pixel,
     FLOAT minimal_penalty
 );
+/**
+ * \brief Construct an array of available differences
+ * between penalties of edges of the neighborhood
+ * with the lowest penalty in the neighborhood.
+ * The output is sorted in ascending order.
+ */
 FLOAT_ARRAY fetch_edge_available_penalties(
     const struct DisparityGraph& graph,
     struct Edge edge,
     FLOAT minimal_penalty
 );
+/**
+ * \brief Construct an array of available differences
+ * gathered from all pixels via ::fetch_pixel_available_penalties
+ * and from all neighbors via ::fetch_edge_available_penalties.
+ * The output is sorted in ascending order.
+ */
 FLOAT_ARRAY fetch_available_penalties(
     const struct LowestPenalties& lowest_penalties
 );
+/**
+ * \brief Calculate the minimal threshold
+ * for ConstraintGraph to have a solution.
+ *
+ * Nodes and edges with low penalty
+ * may be consistent with graphs,
+ * containing nodes and edges with high penalty.
+ *
+ * If we want to have a guarantee
+ * that penalties of nodes and edges of the solution
+ * differ from the lowest penalties
+ * not more than by specified threshold,
+ * we need to solve CSP,
+ * removing all elements,
+ * that have a big deviation from the corresponding minimal values.
+ * The ::solve_csp does this.
+ *
+ * If we want to find the minimal available threshold,
+ * which still allows the problem to be solvable,
+ * we can find it using the following conclusions:
+ *
+ *   - Set of all available thresholds contains only differences
+ *   between penalties of nodes and corresponding best nodes,
+ *   and differences between penalties of edges
+ *   and corresponding best edges.
+ *   - We can use a binary search to find the best threshold,
+ *   using ::solve_csp as the \f$ \ge \f$ comparison
+ *   between the following solution and the best one.
+ *
+ * The algorithm:
+ *
+ *   -# Initialize indices of the first \f$ f \f$ and the last \f$ \ell \f$
+ *   indices of the array.
+ *   -# Set the current index \f$ i \gets \frac{f + \ell}{2} \f$.
+ *   -# If \f$ f = \ell \f$,
+ *   the solution is the \f$ i \f$-th threshold from the list.
+ *   Finish the algorithm.
+ *   -# If the problem is solvable,
+ *   move the end to the center \f$ \ell \gets i \f$.
+ *   -# Otherwise, move the start just after the center \f$ f \gets i + 1 \f$.
+ *   -# Go to step `2`.
+ *
+ * This allows us to execute ::solve_csp
+ * not more than \f$ \left[ \log_2 \ell + 1 \right] \f$ times.
+ */
 FLOAT calculate_minimal_consistent_threshold(
     const struct LowestPenalties& lowest_penalties,
     const struct DisparityGraph& disparity_graph,
     FLOAT_ARRAY available_penalties
 );
+/**
+ * \brief Leave only the best available node in the pixel.
+ * Remove all other nodes
+ * (mark them as unavailable with ::make_node_unavailable).
+ */
 struct ConstraintGraph* choose_best_node(
     struct ConstraintGraph* graph,
     struct Pixel pixel
 );
+/**
+ * \brief Find a labeling, consistent with the minimal available threshold.
+ *
+ * Use ::calculate_minimal_consistent_threshold
+ * to find the threshold.
+ * For each pixel
+ *
+ *   - execute ::choose_best_node to use the best node;
+ *   - run ::solve_csp for the graph
+ *   to remove inconsistent nodes and edges.
+ *
+ * As the result,
+ * we will have a graph,
+ * where the maximal deviation
+ * from the best penalty in each node and edge
+ * will be minimal.
+ */
 struct ConstraintGraph* find_labeling(struct ConstraintGraph* graph);
 
 #endif

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * @file
+ */
+#ifndef LABELING_FINDER_HPP
+#define LABELING_FINDER_HPP
+
+#include <lowest_penalties.hpp>
+
+FLOAT_ARRAY fetch_pixel_available_penalties(
+    struct Pixel pixel,
+    const struct LowestPenalties& lowest_penalties
+);
+FLOAT_ARRAY fetch_edge_available_penalties(
+    struct Edge edge,
+    const struct LowestPenalties& lowest_penalties
+);
+FLOAT_ARRAY fetch_available_penalties(
+    const struct LowestPenalties& lowest_penalties
+);
+
+#endif

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -48,11 +48,9 @@ FLOAT calculate_minimal_consistent_threshold(
     FLOAT_ARRAY available_penalties
 );
 struct ConstraintGraph* choose_best_node(
-    struct ConstraintGraph* constraint_graph,
+    struct ConstraintGraph* graph,
     struct Pixel pixel
 );
-struct ConstraintGraph* find_labeling(
-    struct ConstraintGraph* constraint_graph
-);
+struct ConstraintGraph* find_labeling(struct ConstraintGraph* graph);
 
 #endif

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -30,12 +30,14 @@
 #include <lowest_penalties.hpp>
 
 FLOAT_ARRAY fetch_pixel_available_penalties(
+    const DisparityGraph& graph,
     struct Pixel pixel,
-    const struct LowestPenalties& lowest_penalties
+    FLOAT minimal_penalty
 );
 FLOAT_ARRAY fetch_edge_available_penalties(
+    const struct DisparityGraph& graph,
     struct Edge edge,
-    const struct LowestPenalties& lowest_penalties
+    FLOAT minimal_penalty
 );
 FLOAT_ARRAY fetch_available_penalties(
     const struct LowestPenalties& lowest_penalties

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -42,5 +42,17 @@ FLOAT_ARRAY fetch_edge_available_penalties(
 FLOAT_ARRAY fetch_available_penalties(
     const struct LowestPenalties& lowest_penalties
 );
+FLOAT calculate_minimal_consistent_threshold(
+    const struct LowestPenalties& lowest_penalties,
+    const struct DisparityGraph& disparity_graph,
+    FLOAT_ARRAY available_penalties
+);
+struct ConstraintGraph* choose_best_node(
+    struct ConstraintGraph* constraint_graph,
+    struct Pixel pixel
+);
+struct ConstraintGraph* find_labeling(
+    struct ConstraintGraph* constraint_graph
+);
 
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(pgm_io pgm_io.cpp)
 add_library(disparity_graph disparity_graph.cpp)
 add_library(lowest_penalties lowest_penalties.cpp)
 add_library(constraint_graph constraint_graph.cpp)
+add_library(labeling_finder labeling_finder.cpp)
 target_include_directories(
     image PUBLIC
     ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
@@ -44,6 +45,10 @@ target_include_directories(
     constraint_graph PUBLIC
     ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
 )
+target_include_directories(
+    labeling_finder PUBLIC
+    ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
+)
 target_link_libraries(
     pgm_io
     image
@@ -58,6 +63,13 @@ target_link_libraries(
     image
 )
 target_link_libraries(
+    constraint_graph
+    lowest_penalties
+    disparity_graph
+    image
+)
+target_link_libraries(
+    labeling_finder
     constraint_graph
     lowest_penalties
     disparity_graph
@@ -77,5 +89,6 @@ target_link_libraries(
     pgm_io
     disparity_graph
     constraint_graph
+    labeling_finder
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -28,8 +28,8 @@
 #include <lowest_penalties.hpp>
 
 #include <algorithm>
-#include <stdexcept>
 #include <iterator>
+#include <stdexcept>
 
 FLOAT_ARRAY fetch_pixel_available_penalties(
     const DisparityGraph& graph,

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -236,7 +236,8 @@ struct ConstraintGraph* choose_best_node(
         {
             continue;
         }
-        else if (minimal_penalty < 0)
+
+        if (minimal_penalty < 0)
         {
             minimal_penalty = node_penalty(graph->disparity_graph, node);
         }

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -1,0 +1,184 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <labeling_finder.hpp>
+
+#include <algorithm>
+#include <iterator>
+
+FLOAT_ARRAY fetch_pixel_available_penalties(
+    struct Pixel pixel,
+    FLOAT minimal_penalty,
+    const DisparityGraph& graph
+)
+{
+    FLOAT_ARRAY result(
+        pixel.x + graph.disparity_levels < graph.left.width + 1
+        ? graph.disparity_levels
+        : graph.left.width - pixel.x
+    );
+    Node node{pixel, 0};
+    for (
+        node.disparity = 0;
+        node.disparity < result.size();
+        ++node.disparity
+    )
+    {
+        result[node.disparity] = (
+            node_penalty(graph, node)
+            - minimal_penalty
+        );
+    }
+
+    std::sort(result.begin(), result.end());
+    auto last = std::unique(result.begin(), result.end());
+    result.erase(last, result.end());
+
+    return result;
+}
+
+FLOAT_ARRAY fetch_edge_available_penalties(
+    const struct DisparityGraph& graph,
+    FLOAT minimal_penalty,
+    struct Edge edge
+)
+{
+    FLOAT_ARRAY result;
+
+    ULONG initial_disparity = 0;
+    for (
+        edge.node.disparity = 0;
+        edge.node.pixel.x + edge.node.disparity < graph.left.width
+            && edge.node.disparity < graph.disparity_levels;
+        ++edge.node.disparity
+    )
+    {
+        if (
+            edge.node.disparity <= 1
+            || edge.neighbor.pixel.x == edge.node.pixel.x
+        )
+        {
+            initial_disparity = 0;
+        }
+        else
+        {
+            initial_disparity = edge.node.disparity - 1;
+        }
+        for (
+            edge.neighbor.disparity = initial_disparity;
+            edge.neighbor.pixel.x + edge.neighbor.disparity < graph.left.width
+                && edge.neighbor.disparity < graph.disparity_levels;
+            ++edge.neighbor.disparity
+        )
+        {
+            result.push_back(edge_penalty(graph, edge) - minimal_penalty);
+        }
+    }
+
+    std::sort(result.begin(), result.end());
+    auto last = std::unique(result.begin(), result.end());
+    result.erase(last, result.end());
+
+    return result;
+}
+
+FLOAT_ARRAY fetch_available_penalties(
+    const struct LowestPenalties& lowest_penalties
+)
+{
+    FLOAT_ARRAY result;
+    FLOAT_ARRAY result_;
+    FLOAT_ARRAY available_penalties;
+    struct Pixel pixel{0, 0};
+    for (pixel.x = 0; pixel.x < lowest_penalties.graph.right.width; ++pixel.x)
+    {
+        for (
+            pixel.y = 0;
+            pixel.y < lowest_penalties.graph.right.height;
+            ++pixel.y)
+        {
+            available_penalties = fetch_pixel_available_penalties(
+                pixel,
+                lowest_pixel_penalty(lowest_penalties, pixel),
+                lowest_penalties.graph
+            );
+            std::merge(
+                result.begin(),
+                result.end(),
+                available_penalties.begin(),
+                available_penalties.end(),
+                std::back_inserter(result_)
+            );
+            std::swap(result, result_);
+            result_.clear();
+            available_penalties.clear();
+
+            std::sort(result.begin(), result.end());
+            auto last = std::unique(result.begin(), result.end());
+            result.erase(last, result.end());
+
+            for (
+                ULONG neighbor_index = 0;
+                neighbor_index < NEIGHBORS_COUNT;
+                ++neighbor_index
+            )
+            {
+                if (
+                    !neighborhood_exists_fast(
+                        lowest_penalties.graph, pixel, neighbor_index
+                    )
+                )
+                {
+                    continue;
+                }
+                Edge edge{
+                    {pixel, 0},
+                    {neighbor_by_index(pixel, neighbor_index), 0}
+                };
+                available_penalties = fetch_edge_available_penalties(
+                    lowest_penalties.graph,
+                    lowest_neighborhood_penalty(
+                        lowest_penalties,
+                        edge
+                    ),
+                    edge
+                );
+                std::merge(
+                    result.begin(),
+                    result.end(),
+                    available_penalties.begin(),
+                    available_penalties.end(),
+                    std::back_inserter(result_)
+                );
+                std::swap(result, result_);
+                result_.clear();
+                available_penalties.clear();
+
+                std::sort(result.begin(), result.end());
+                auto last = std::unique(result.begin(), result.end());
+                result.erase(last, result.end());
+            }
+        }
+    }
+    return result;
+}

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -22,14 +22,17 @@
  * SOFTWARE.
  */
 #include <labeling_finder.hpp>
+#include <constraint_graph.hpp>
+#include <disparity_graph.hpp>
+#include <lowest_penalties.hpp>
 
 #include <algorithm>
 #include <iterator>
 
 FLOAT_ARRAY fetch_pixel_available_penalties(
+    const DisparityGraph& graph,
     struct Pixel pixel,
-    FLOAT minimal_penalty,
-    const DisparityGraph& graph
+    FLOAT minimal_penalty
 )
 {
     FLOAT_ARRAY result(
@@ -59,8 +62,8 @@ FLOAT_ARRAY fetch_pixel_available_penalties(
 
 FLOAT_ARRAY fetch_edge_available_penalties(
     const struct DisparityGraph& graph,
-    FLOAT minimal_penalty,
-    struct Edge edge
+    struct Edge edge,
+    FLOAT minimal_penalty
 )
 {
     FLOAT_ARRAY result;
@@ -118,9 +121,9 @@ FLOAT_ARRAY fetch_available_penalties(
             ++pixel.y)
         {
             available_penalties = fetch_pixel_available_penalties(
+                lowest_penalties.graph,
                 pixel,
-                lowest_pixel_penalty(lowest_penalties, pixel),
-                lowest_penalties.graph
+                lowest_pixel_penalty(lowest_penalties, pixel)
             );
             std::merge(
                 result.begin(),
@@ -157,11 +160,11 @@ FLOAT_ARRAY fetch_available_penalties(
                 };
                 available_penalties = fetch_edge_available_penalties(
                     lowest_penalties.graph,
+                    edge,
                     lowest_neighborhood_penalty(
                         lowest_penalties,
                         edge
-                    ),
-                    edge
+                    )
                 );
                 std::merge(
                     result.begin(),

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -273,7 +273,7 @@ struct ConstraintGraph* choose_best_node(
             node_chosen = true;
         }
     }
-    return node_chosen? graph : NULL;
+    return node_chosen? graph : nullptr;
 }
 
 struct ConstraintGraph* find_labeling(
@@ -284,13 +284,13 @@ struct ConstraintGraph* find_labeling(
     {
         for (ULONG y = 0; y < graph->disparity_graph.left.height; ++y)
         {
-            if (!choose_best_node(graph, {x, y}))
+            if (choose_best_node(graph, {x, y}) == nullptr)
             {
-                return NULL;
+                return nullptr;
             }
             if (!solve_csp(graph))
             {
-                return NULL;
+                return nullptr;
             }
         }
     }

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -28,7 +28,7 @@
 #include <lowest_penalties.hpp>
 
 #include <algorithm>
-#include <exception>
+#include <stdexcept>
 #include <iterator>
 
 FLOAT_ARRAY fetch_pixel_available_penalties(

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -23,6 +23,7 @@
  */
 #include <constraint_graph.hpp>
 #include <disparity_graph.hpp>
+#include <image.hpp>
 #include <labeling_finder.hpp>
 #include <lowest_penalties.hpp>
 
@@ -296,4 +297,49 @@ struct ConstraintGraph* find_labeling(
         }
     }
     return graph;
+}
+
+struct Image build_disparity_map(
+    const struct ConstraintGraph& constraint_graph
+)
+{
+    struct Image result{
+        constraint_graph.disparity_graph.left.width,
+        constraint_graph.disparity_graph.left.height,
+        constraint_graph.disparity_graph.disparity_levels,
+        ULONG_ARRAY(
+            constraint_graph.disparity_graph.left.height
+            * constraint_graph.disparity_graph.left.width
+        )
+    };
+    Node node{{0, 0}, 0};
+    for (
+        node.pixel.x = 0;
+        node.pixel.x < constraint_graph.disparity_graph.left.width;
+        ++node.pixel.x)
+    {
+        for (
+            node.pixel.y = 0;
+            node.pixel. y < constraint_graph.disparity_graph.left.height;
+            ++node.pixel.y)
+        {
+            for (
+                node.disparity = 0;
+                node.pixel.x + node.disparity
+                    < constraint_graph.disparity_graph.left.width
+                && node.disparity
+                    < constraint_graph.disparity_graph.disparity_levels;
+                ++node.disparity
+            )
+            {
+                if (is_node_available(constraint_graph, node))
+                {
+                    result.data[get_pixel_index(result, node.pixel)]
+                        = node.disparity;
+                    break;
+                }
+            }
+        }
+    }
+    return result;
 }

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -21,9 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include <labeling_finder.hpp>
 #include <constraint_graph.hpp>
 #include <disparity_graph.hpp>
+#include <labeling_finder.hpp>
 #include <lowest_penalties.hpp>
 
 #include <algorithm>

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -28,6 +28,7 @@
 #include <lowest_penalties.hpp>
 
 #include <algorithm>
+#include <exception>
 #include <iterator>
 
 FLOAT_ARRAY fetch_pixel_available_penalties(
@@ -313,6 +314,7 @@ struct Image build_disparity_map(
         )
     };
     Node node{{0, 0}, 0};
+    BOOL found = false;
     for (
         node.pixel.x = 0;
         node.pixel.x < constraint_graph.disparity_graph.left.width;
@@ -334,11 +336,33 @@ struct Image build_disparity_map(
             {
                 if (is_node_available(constraint_graph, node))
                 {
+                    if (found)
+                    {
+                        throw std::logic_error(
+                            "Two labels found for the pixel <"
+                            + std::to_string(node.pixel.x)
+                            + ", "
+                            + std::to_string(node.pixel.y)
+                            + ">."
+                        );
+                    }
                     result.data[get_pixel_index(result, node.pixel)]
                         = node.disparity;
+                    found = true;
                     break;
                 }
             }
+            if (!found)
+            {
+                throw std::logic_error(
+                    "Cannot find label for the pixel <"
+                    + std::to_string(node.pixel.x)
+                    + ", "
+                    + std::to_string(node.pixel.y)
+                    + ">."
+                );
+            }
+            found = false;
         }
     }
     return result;

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -261,7 +261,8 @@ struct ConstraintGraph* choose_best_node(
         {
             continue;
         }
-        else if (
+
+        if (
             node_chosen
             || node_penalty(graph->disparity_graph, node) > minimal_penalty
         )

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char* argv[]) try
                     "Refer to the developers."
                 );
             }
-            if (!find_labeling(&constraint_graph))
+            if (find_labeling(&constraint_graph) == nullptr)
             {
                 throw std::logic_error(
                     "Cannot find labeling. "

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -1,17 +1,17 @@
 #include <boost/program_options.hpp>
 
-#include <fstream>
-#include <iostream>
-#include <memory>
-#include <stdexcept>
-#include <string>
-
 #include <constraint_graph.hpp>
 #include <disparity_graph.hpp>
 #include <image.hpp>
 #include <labeling_finder.hpp>
 #include <lowest_penalties.hpp>
 #include <pgm_io.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
 
 struct Image read_image(const std::string& image_path);
 

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -116,8 +116,22 @@ int main(int argc, char* argv[]) try
                 lowest_penalties,
                 threshold
             };
-            solve_csp(&constraint_graph);
-            find_labeling(&constraint_graph);
+            if (!solve_csp(&constraint_graph))
+            {
+                throw std::logic_error(
+                    "Cannot solve CSP problem. "
+                    "This should not ever happen. "
+                    "Refer to the developers."
+                );
+            }
+            if (!find_labeling(&constraint_graph))
+            {
+                throw std::logic_error(
+                    "Cannot find labeling. "
+                    "This should not ever happen. "
+                    "Refer to the developers."
+                );
+            }
 
             std::shared_ptr<struct Image> result
                 = std::make_shared<struct Image>(build_disparity_map(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
     disparity_graph.cpp
     constraint_graph.cpp
     lowest_penalties.cpp
+    labeling_finder.cpp
 )
 target_include_directories(test_executable PRIVATE ${BOOST_INCLUDE_DIRS})
 target_link_libraries(
@@ -38,6 +39,7 @@ target_link_libraries(
     disparity_graph
     constraint_graph
     lowest_penalties
+    labeling_finder
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
 )
 target_compile_definitions(

--- a/tests/labeling_finder.cpp
+++ b/tests/labeling_finder.cpp
@@ -1,0 +1,226 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <boost/test/unit_test.hpp>
+
+#include <labeling_finder.hpp>
+#include <constraint_graph.hpp>
+#include <disparity_graph.hpp>
+#include <image.hpp>
+#include <lowest_penalties.hpp>
+#include <pgm_io.hpp>
+
+BOOST_AUTO_TEST_SUITE(LabelingFinder)
+
+BOOST_AUTO_TEST_CASE(check_black_images)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    2
+    0 0 0
+    0 0 0
+    )image"};
+
+    image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{image, image, 2, 1, 1};
+    struct LowestPenalties lowest_penalties{disparity_graph};
+    auto pixel_penalties = fetch_pixel_available_penalties(
+        disparity_graph,
+        {0, 0},
+        0
+    );
+    BOOST_CHECK_EQUAL(pixel_penalties.size(), 1);
+    BOOST_CHECK_CLOSE(pixel_penalties[0], 0, 1);
+
+    auto edge_penalties = fetch_edge_available_penalties(
+        disparity_graph,
+        {{{0, 0}, 0}, {{0, 1}, 0}},
+        0
+    );
+    BOOST_CHECK_EQUAL(edge_penalties.size(), 2);
+    BOOST_CHECK_CLOSE(edge_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(edge_penalties[1], 1, 1);
+
+    auto available_penalties = fetch_available_penalties(lowest_penalties);
+    BOOST_CHECK_EQUAL(available_penalties.size(), 2);
+    BOOST_CHECK_CLOSE(available_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(available_penalties[1], 1, 1);
+
+    FLOAT threshold = calculate_minimal_consistent_threshold(
+        lowest_penalties,
+        disparity_graph,
+        available_penalties
+    );
+    BOOST_CHECK_CLOSE(threshold, 0, 1);
+
+    struct ConstraintGraph constraint_graph{
+        disparity_graph,
+        lowest_penalties,
+        threshold
+    };
+    BOOST_TEST(solve_csp(&constraint_graph));
+    BOOST_CHECK_EQUAL(find_labeling(&constraint_graph), &constraint_graph);
+}
+
+BOOST_AUTO_TEST_CASE(check_equal_images)
+{
+    PGM_IO pgm_io;
+    std::istringstream image_content{R"image(
+    P2
+    3 2
+    256
+    0   127 256
+    256 127 0
+    )image"};
+
+    image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
+    struct LowestPenalties lowest_penalties{disparity_graph};
+
+    auto pixel_penalties = fetch_pixel_available_penalties(
+        disparity_graph,
+        {1, 0},
+        0
+    );
+    BOOST_CHECK_EQUAL(pixel_penalties.size(), 2);
+    BOOST_CHECK_CLOSE(pixel_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(pixel_penalties[1], 129 * 129, 1);
+
+    auto edge_penalties = fetch_edge_available_penalties(
+        disparity_graph,
+        {{{0, 0}, 0}, {{0, 1}, 0}},
+        0
+    );
+    BOOST_CHECK_EQUAL(edge_penalties.size(), 3);
+    BOOST_CHECK_CLOSE(edge_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(edge_penalties[1], 1, 1);
+    BOOST_CHECK_CLOSE(edge_penalties[2], 4, 1);
+
+    auto available_penalties = fetch_available_penalties(lowest_penalties);
+    BOOST_CHECK_EQUAL(available_penalties.size(), 6);
+    BOOST_CHECK_CLOSE(available_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(available_penalties[1], 1, 1);
+    BOOST_CHECK_CLOSE(available_penalties[2], 4, 1);
+    BOOST_CHECK_CLOSE(available_penalties[3], 127 * 127, 1);
+    BOOST_CHECK_CLOSE(available_penalties[4], 129 * 129, 1);
+    BOOST_CHECK_CLOSE(available_penalties[5], 256 * 256, 1);
+
+    FLOAT threshold = calculate_minimal_consistent_threshold(
+        lowest_penalties,
+        disparity_graph,
+        available_penalties
+    );
+    BOOST_CHECK_CLOSE(threshold, 0, 1);
+
+    struct ConstraintGraph constraint_graph{
+        disparity_graph,
+        lowest_penalties,
+        threshold
+    };
+    BOOST_TEST(solve_csp(&constraint_graph));
+    BOOST_CHECK_EQUAL(find_labeling(&constraint_graph), &constraint_graph);
+}
+
+BOOST_AUTO_TEST_CASE(basic_check)
+{
+    PGM_IO pgm_io;
+    std::istringstream left_image_content{R"image(
+    P2
+    3 2
+    10
+    4 5 10
+    0 0 0
+    )image"};
+    std::istringstream right_image_content{R"image(
+    P2
+    3 2
+    10
+    10 7 0
+    0 0 0
+    )image"};
+
+    left_image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image left_image{*pgm_io.get_image()};
+
+    right_image_content >> pgm_io;
+    BOOST_REQUIRE(pgm_io.get_image());
+    struct Image right_image{*pgm_io.get_image()};
+
+    struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
+    struct LowestPenalties lowest_penalties{disparity_graph};
+
+    auto pixel_penalties = fetch_pixel_available_penalties(
+        disparity_graph,
+        {0, 0},
+        0
+    );
+    BOOST_CHECK_EQUAL(pixel_penalties.size(), 3);
+    BOOST_CHECK_CLOSE(pixel_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(pixel_penalties[1], 25, 1);
+    BOOST_CHECK_CLOSE(pixel_penalties[2], 36, 1);
+
+    auto edge_penalties = fetch_edge_available_penalties(
+        disparity_graph,
+        {{{0, 0}, 0}, {{0, 1}, 0}},
+        0
+    );
+    BOOST_CHECK_EQUAL(edge_penalties.size(), 3);
+    BOOST_CHECK_CLOSE(edge_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(edge_penalties[1], 1, 1);
+    BOOST_CHECK_CLOSE(edge_penalties[2], 4, 1);
+
+    auto available_penalties = fetch_available_penalties(lowest_penalties);
+    BOOST_CHECK_EQUAL(available_penalties.size(), 6);
+    BOOST_CHECK_CLOSE(available_penalties[0], 0, 1);
+    BOOST_CHECK_CLOSE(available_penalties[1], 1, 1);
+    BOOST_CHECK_CLOSE(available_penalties[2], 4, 1);
+    BOOST_CHECK_CLOSE(available_penalties[3], 5, 1);
+    BOOST_CHECK_CLOSE(available_penalties[4], 25, 1);
+    BOOST_CHECK_CLOSE(available_penalties[5], 36, 1);
+
+    FLOAT threshold = calculate_minimal_consistent_threshold(
+        lowest_penalties,
+        disparity_graph,
+        available_penalties
+    );
+    BOOST_CHECK_CLOSE(threshold, 5, 1);
+
+    struct ConstraintGraph constraint_graph{
+        disparity_graph,
+        lowest_penalties,
+        threshold
+    };
+    BOOST_TEST(solve_csp(&constraint_graph));
+    BOOST_CHECK_EQUAL(find_labeling(&constraint_graph), &constraint_graph);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/labeling_finder.cpp
+++ b/tests/labeling_finder.cpp
@@ -23,10 +23,10 @@
  */
 #include <boost/test/unit_test.hpp>
 
-#include <labeling_finder.hpp>
 #include <constraint_graph.hpp>
 #include <disparity_graph.hpp>
 #include <image.hpp>
+#include <labeling_finder.hpp>
 #include <lowest_penalties.hpp>
 #include <pgm_io.hpp>
 

--- a/tests/labeling_finder.cpp
+++ b/tests/labeling_finder.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
         lowest_penalties,
         threshold
     };
-    BOOST_TEST(solve_csp(&constraint_graph));
+    BOOST_CHECK(solve_csp(&constraint_graph));
     BOOST_CHECK_EQUAL(find_labeling(&constraint_graph), &constraint_graph);
 }
 
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
         lowest_penalties,
         threshold
     };
-    BOOST_TEST(solve_csp(&constraint_graph));
+    BOOST_CHECK(solve_csp(&constraint_graph));
     BOOST_CHECK_EQUAL(find_labeling(&constraint_graph), &constraint_graph);
 }
 
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(basic_check)
         lowest_penalties,
         threshold
     };
-    BOOST_TEST(solve_csp(&constraint_graph));
+    BOOST_CHECK(solve_csp(&constraint_graph));
     BOOST_CHECK_EQUAL(find_labeling(&constraint_graph), &constraint_graph);
 }
 


### PR DESCRIPTION
This part is the first gathering point for what we have now.
The algorithm calculates the minimal available threshold for constraint graph,
removes all vertices and edges that violate the border value,
and then one more exciting part begins.
For the stereo vision problem (in this formulation)
it's true that, if the corresponding constraint problem has a solution,
then, leaving only one available node in a chosen pixel,
we still have a correct answer.
Thus, we can repeat the procedure for all pixels
and this will give us a solution,
satisfying chosen (minimal available) threshold.
Genius!

During working on this task,
I've found an annoying bug #87.
It wasn't easy to locate and reproduce it for different cases.

The code works surprisingly slow because of many checks after each node removal.
A solution of #90 will make it feel better.