### PR TITLE
Close #91: Refactor the code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -147,6 +147,26 @@ Added
   of a neighborhood from ``neighborhoods`` of ``LowestPenalties``
   given coordinates of a pixel and its neighbor.
 
+- Functions to find a consistent labeling
+
+  - ``fetch_pixel_available_penalties``
+    to find the available penalties of all nodes;
+  - ``fetch_edge_available_penalties``
+    to find the available penalties of all edges;
+  - ``fetch_available_penalties``
+    to find and fuse both nodes' and edges' penalties;
+  - ``calculate_minimal_consistent_threshold``
+    to find the minimal threshold of the ``ConstraintGraph``
+    for the problem to still be solvable;
+  - ``choose_best_node``
+    to leave only one node with the lowest penalty at specific pixel;
+    if a pixel has two nodes with the same penalty,
+    the one with the lower disparity will be chosen;
+  - ``find_labeling``
+    to remove all non-best nodes;
+  - ``build_disparity_map``
+    to build a grayscale image with the solution to the problem.
+
 .. Remove these two lines and one indentation level of the next two lines
     when you will release the first version.
     .. _Unreleased:

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -22,7 +22,6 @@
  * SOFTWARE.
  */
 #include <constraint_graph.hpp>
-
 #include <disparity_graph.hpp>
 #include <lowest_penalties.hpp>
 
@@ -241,7 +240,7 @@ BOOL csp_solution_iteration(struct ConstraintGraph* graph)
         node.pixel.x < graph->disparity_graph.right.width;
         ++node.pixel.x
     )
-        {
+    {
         for (
             node.pixel.y = 0;
             node.pixel.y < graph->disparity_graph.right.height;

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -339,8 +339,7 @@ FLOAT edge_penalty(const struct DisparityGraph& graph, struct Edge edge)
 
 FLOAT node_penalty(const struct DisparityGraph& graph, struct Node node)
 {
-    Pixel left_pixel = node.pixel;
-    left_pixel.x += node.disparity;
+    Pixel left_pixel{node.pixel.x + node.disparity, node.pixel.y};
     return
         graph.cleanness
         * SQR(TO_FLOAT(get_pixel_value(graph.right, node.pixel))

--- a/lib/lowest_penalties.cpp
+++ b/lib/lowest_penalties.cpp
@@ -126,24 +126,23 @@ Pixel neighbor_by_index(
     ULONG neighbor_index
 )
 {
-    struct Pixel neighbor{pixel};
     if (neighbor_index == 0)
     {
-        ++neighbor.x;
+        ++pixel.x;
     }
     else if (neighbor_index == 1)
     {
-        --neighbor.x;
+        --pixel.x;
     }
     else if (neighbor_index == 2)
     {
-        ++neighbor.y;
+        ++pixel.y;
     }
     else if (neighbor_index == 3)
     {
-        --neighbor.y;
+        --pixel.y;
     }
-    return neighbor;
+    return pixel;
 }
 
 FLOAT calculate_lowest_pixel_penalty(


### PR DESCRIPTION
Some things were forgotten. It's time to fix them.

- Remove redundant indent in constraint graph module.
- Remove redundant new line in constraint graph module.
- Use a constructor instead of field mutation in the node penalty calculation.
- Process the input pixel copy instead of creating a copy of the copy.
- Add information about the labeling finding functions to the CHANGELOG.