### PR TITLE
Close #68: Create a separate file with basic types

### DIFF
--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -30,19 +30,6 @@
 #include <disparity_graph.hpp>
 #include <image.hpp>
 
-#include <vector>
-
-/**
- * \brief Boolean type alias.
- * to use the same name on CPU and GPU.
- */
-using BOOL = bool;
-/**
- * \brief Boolean array type alias
- * to use the same name on CPU and GPU.
- */
-using BOOL_ARRAY = std::vector<BOOL>;
-
 /**
  * \brief Structure to represent a graph with constraints
  * on choice of disparities for pixels (constraint satisfaction problem, CSP).

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -397,40 +397,6 @@ struct DisparityGraph
     );
 };
 
-/**
- * \brief Node of DisparityGraph is a pair
- * consisting of Pixel and disparity assigned to it.
- */
-struct Node
-{
-    /**
-     * \brief Pixel to which the Node instance belongs.
-     */
-    struct Pixel pixel;
-    /**
-     * \brief Disparity assigned to the Node::pixel in the Node instance.
-     *
-     * Disparity specifies the difference between columns
-     * of current pixel on the right image
-     * and corresponding one on the left image.
-     */
-    ULONG disparity;
-};
-
-/**
- * \brief Edge is an ordered pair of two Node instances.
- */
-struct Edge
-{
-    /**
-     * \brief Start Node of the directed Edge.
-     */
-    struct Node node;
-    /**
-     * \brief Start Node of the directed Edge.
-     */
-    struct Node neighbor;
-};
 
 /**
  * \brief Get index of a neighbor for fast access in different data arrays.

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -30,20 +30,9 @@
 #include <image.hpp>
 
 #include <algorithm>
-#include <vector>
 
 #define MAX(x, y) ((x) >= (y)? (x) : (y))
 
-/**
- * \brief Floating point type alias.
- * to use the same name on CPU and GPU.
- */
-using FLOAT = double;
-/**
- * \brief Floating point array type alias
- * to use the same name on CPU and GPU.
- */
-using FLOAT_ARRAY = std::vector<FLOAT>;
 /**
  * \brief Maximal number of neighbors of each vertex of disparity graph.
  *

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -27,18 +27,7 @@
 #ifndef IMAGE_HPP
 #define IMAGE_HPP
 
-#include <vector>
-
-/**
- * \brief Unsigned long type alias
- * to use the same name on CPU and GPU.
- */
-using ULONG = unsigned long;
-/**
- * \brief Unsigned long array type alias
- * to use the same name on CPU and GPU.
- */
-using ULONG_ARRAY = std::vector<ULONG>;
+#include <types.hpp>
 
 /**
  * \brief Structure to represent image on both CPU and GPU.
@@ -81,21 +70,6 @@ struct Image
      * \f]
      */
     ULONG_ARRAY data;
-};
-
-/**
- * Structure that contains position of a pixel.
- */
-struct Pixel
-{
-    /**
-     * \brief Column (horizontal offset) of the pixel.
-     */
-    ULONG x;
-    /**
-     * \brief Row (vertical offset) of the pixel.
-     */
-    ULONG y;
 };
 
 /**

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -54,6 +54,17 @@ using FLOAT = double;
 using FLOAT_ARRAY = std::vector<FLOAT>;
 
 /**
+ * \brief Boolean type alias.
+ * to use the same name on CPU and GPU.
+ */
+using BOOL = bool;
+/**
+ * \brief Boolean array type alias
+ * to use the same name on CPU and GPU.
+ */
+using BOOL_ARRAY = std::vector<BOOL>;
+
+/**
  * Structure that contains position of a pixel.
  */
 struct Pixel

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -42,6 +42,18 @@ using ULONG = unsigned long;
 using ULONG_ARRAY = std::vector<ULONG>;
 
 /**
+ * \brief Floating point type alias.
+ * to use the same name on CPU and GPU.
+ */
+using FLOAT = double;
+
+/**
+ * \brief Floating point array type alias
+ * to use the same name on CPU and GPU.
+ */
+using FLOAT_ARRAY = std::vector<FLOAT>;
+
+/**
  * Structure that contains position of a pixel.
  */
 struct Pixel

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -79,4 +79,39 @@ struct Pixel
     ULONG y;
 };
 
+/**
+ * \brief Node of DisparityGraph is a pair
+ * consisting of Pixel and disparity assigned to it.
+ */
+struct Node
+{
+    /**
+     * \brief Pixel to which the Node instance belongs.
+     */
+    struct Pixel pixel;
+    /**
+     * \brief Disparity assigned to the Node::pixel in the Node instance.
+     *
+     * Disparity specifies the difference between columns
+     * of current pixel on the right image
+     * and corresponding one on the left image.
+     */
+    ULONG disparity;
+};
+
+/**
+ * \brief Edge is an ordered pair of two Node instances.
+ */
+struct Edge
+{
+    /**
+     * \brief Start Node of the directed Edge.
+     */
+    struct Node node;
+    /**
+     * \brief Start Node of the directed Edge.
+     */
+    struct Node neighbor;
+};
+
 #endif

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018-2019 char-lie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * @file
+ */
+#ifndef TYPES_HPP
+#define TYPES_HPP
+
+#include <vector>
+
+/**
+ * \brief Unsigned long type alias
+ * to use the same name on CPU and GPU.
+ */
+using ULONG = unsigned long;
+
+/**
+ * \brief Unsigned long array type alias
+ * to use the same name on CPU and GPU.
+ */
+using ULONG_ARRAY = std::vector<ULONG>;
+
+/**
+ * Structure that contains position of a pixel.
+ */
+struct Pixel
+{
+    /**
+     * \brief Column (horizontal offset) of the pixel.
+     */
+    ULONG x;
+    /**
+     * \brief Row (vertical offset) of the pixel.
+     */
+    ULONG y;
+};
+
+#endif


### PR DESCRIPTION
Move the following type aliases and structures to `types`

- `Pixel`, `ULONG`, and `ULONG_ARRAY` from `image`
- `FLOAT`, `FLOAT_ARRAY`, `Node`, and `Edge` from `disparity_graph`
- `BOOL`, and `BOOL_ARRAY` from `constraint_graph`

Yesterday, I've tried to do a global restructure of all modules.
It was hard and awful.
So, I've decided simply to move all simple types to a separate module,
as well as indexing functions (task #93).