### PR TITLE
Close #97: Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.sw[op]
+build/*
+tags


### PR DESCRIPTION
I'm tired of `git` propositions to add swap files of VIM, build directory and `ctags` tags.
It's time to ignore these files.