### PR TITLE
Fix #103: CPU+GPU code is not C-compatible

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,5 +13,6 @@
         -cppcoreguidelines-pro-type-vararg,\
         -google-runtime-int,\
         -cppcoreguidelines-pro-type-member-init,\
+        -modernize-use-nullptr,\
     ",
 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,8 +11,10 @@
         -cert-err60-cpp,\
         -clang-diagnostic-unused-command-line-argument,\
         -cppcoreguidelines-pro-type-vararg,\
+        -hicpp-vararg,\
         -google-runtime-int,\
         -cppcoreguidelines-pro-type-member-init,\
+        -hicpp-member-init,\
         -modernize-use-nullptr,\
     ",
 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,5 +12,6 @@
         -clang-diagnostic-unused-command-line-argument,\
         -cppcoreguidelines-pro-type-vararg,\
         -google-runtime-int,\
+        -cppcoreguidelines-pro-type-member-init,\
     ",
 }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ and this project adheres to `Semantic Versioning`_.
 Unreleased_
 ===========
 
+Changed
+-------
+
+- Use pointers instead of references in cross-device code.
+
 0.1.1 - 2019-04-07
 ==================
 

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -270,12 +270,12 @@ struct ConstraintGraph
      * for which the sp::graph::constraint::ConstraintGraph instance
      * was created.
      */
-    const struct DisparityGraph& disparity_graph;
+    const struct DisparityGraph* disparity_graph;
     /**
      * \brief sp::graph::lowest_penalties::LowestPenalties instance
      * to check availability of nodes and edges faster.
      */
-    const struct LowestPenalties& lowest_penalties;
+    const struct LowestPenalties* lowest_penalties;
     /**
      * \brief Array that contains markers for availability of nodes.
      *
@@ -320,8 +320,8 @@ struct ConstraintGraph
      * sp::graph::lowest_penalties::LowestPenalties instance.
      */
     ConstraintGraph(
-        const struct DisparityGraph& disparity_graph,
-        const struct LowestPenalties& lowest_penalties,
+        const struct DisparityGraph* disparity_graph,
+        const struct LowestPenalties* lowest_penalties,
         FLOAT threshold
     );
 };
@@ -361,7 +361,7 @@ void make_all_nodes_unavailable(struct ConstraintGraph* graph);
  * using sp::indexing::checks::node_exists.
  */
 BOOL is_node_available(
-    const struct ConstraintGraph& graph,
+    const struct ConstraintGraph* graph,
     struct Node node
 );
 /**
@@ -376,7 +376,7 @@ BOOL is_node_available(
  * using sp::indexing::checks::edge_exists.
  */
 BOOL is_edge_available(
-    const struct ConstraintGraph& graph,
+    const struct ConstraintGraph* graph,
     struct Edge edge
 );
 /**
@@ -392,7 +392,7 @@ BOOL is_edge_available(
  * using sp::indexing::checks::node_exists.
  */
 BOOL should_remove_node(
-    const struct ConstraintGraph& graph,
+    const struct ConstraintGraph* graph,
     struct Node node
 );
 /**
@@ -432,7 +432,7 @@ BOOL solve_csp(struct ConstraintGraph* graph);
 /**
  * \brief Check whether at least one node is available.
  */
-BOOL check_nodes_left(const struct ConstraintGraph& graph);
+BOOL check_nodes_left(const struct ConstraintGraph* graph);
 
 }
 

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -424,7 +424,7 @@ struct DisparityGraph
  * Otherwise, the penalty is a norm of a difference
  * between disparities of Node instances that the Edge connects.
  */
-FLOAT edge_penalty(const struct DisparityGraph& graph, struct Edge edge);
+FLOAT edge_penalty(const struct DisparityGraph* graph, struct Edge edge);
 /**
  * \brief Calculate penalty of Node.
  *
@@ -436,7 +436,7 @@ FLOAT edge_penalty(const struct DisparityGraph& graph, struct Edge edge);
  * Otherwise, the penalty is a norm of a difference
  * between disparities of Node instances that the Edge connects.
  */
-FLOAT node_penalty(const struct DisparityGraph& graph, struct Node node);
+FLOAT node_penalty(const struct DisparityGraph* graph, struct Node node);
 
 }
 

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -32,6 +32,7 @@
 namespace sp::image
 {
 
+using sp::types::BOOL;
 using sp::types::ULONG;
 using sp::types::ULONG_ARRAY;
 
@@ -85,7 +86,7 @@ struct Image
  * maximal intensity should be greater than zero,
  * and neither intensity should exceed specified maximal value.
  */
-bool image_valid(const struct Image& image);
+BOOL image_valid(const struct Image* image);
 
 }
 

--- a/include/indexing.hpp
+++ b/include/indexing.hpp
@@ -53,7 +53,7 @@ using sp::types::ULONG;
  * Result of accessing non-existent value
  * depends on sp::types::ULONG_ARRAY.
  */
-ULONG pixel_index(const struct Image& image, struct Pixel pixel);
+ULONG pixel_index(const struct Image* image, struct Pixel pixel);
 
 /**
  * \brief Get intensity of the pixel in the image.
@@ -61,7 +61,7 @@ ULONG pixel_index(const struct Image& image, struct Pixel pixel);
  * Simply call sp::indexing::pixel_index and take a value with returned index
  * from Image::data.
  */
-ULONG pixel_value(const struct Image& image, struct Pixel pixel);
+ULONG pixel_value(const struct Image* image, struct Pixel pixel);
 
 /**
  * \brief Get an index of sp::graph::disparity::DisparityGraph::reparametrization element
@@ -72,7 +72,7 @@ ULONG pixel_value(const struct Image& image, struct Pixel pixel);
  * using sp::indexing::checks::neighborhood_exists.
  */
 ULONG reparametrization_index_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     ULONG neighbor_index
 );
@@ -86,7 +86,7 @@ ULONG reparametrization_index_fast(
  * using sp::indexing::checks::neighborhood_exists.
  */
 ULONG reparametrization_index(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     struct Pixel neighbor
 );
@@ -100,7 +100,7 @@ ULONG reparametrization_index(
  * using sp::indexing::checks::neighborhood_exists.
  */
 ULONG reparametrization_index_slow(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 );
 
@@ -113,7 +113,7 @@ ULONG reparametrization_index_slow(
  * using sp::indexing::checks::neighborhood_exists.
  */
 FLOAT reparametrization_value_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     ULONG neighbor_index
 );
@@ -127,7 +127,7 @@ FLOAT reparametrization_value_fast(
  * using sp::indexing::checks::neighborhood_exists.
  */
 FLOAT reparametrization_value(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     struct Pixel neighbor
 );
@@ -141,7 +141,7 @@ FLOAT reparametrization_value(
  * using sp::indexing::checks::neighborhood_exists.
  */
 FLOAT reparametrization_value_slow(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 );
 
@@ -174,7 +174,7 @@ ULONG neighbor_index(
  * You should perform it by yourself
  * using sp::indexing::checks::node_exists.
  */
-ULONG node_index(const struct DisparityGraph& graph, struct Node node);
+ULONG node_index(const struct DisparityGraph* graph, struct Node node);
 
 /**
  * \brief Get index of a neighborhood in
@@ -184,7 +184,7 @@ ULONG node_index(const struct DisparityGraph& graph, struct Node node);
  * Use sp::indexing::checks::neighborhood_exists_fast to make sure that you use it right.
  */
 ULONG neighborhood_index_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     ULONG neighbor_index
 );
@@ -196,7 +196,7 @@ ULONG neighborhood_index_fast(
  * Use sp::indexing::checks::neighborhood_exists to make sure that you use it right.
  */
 ULONG neighborhood_index(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     struct Pixel neighbor
 );
@@ -208,7 +208,7 @@ ULONG neighborhood_index(
  * Use sp::indexing::checks::edge_exists to make sure that you use it right.
  */
 ULONG neighborhood_index_slow(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 );
 
@@ -218,7 +218,7 @@ ULONG neighborhood_index_slow(
  * Note that the function doesn't check existence of provided neighborhood.
  * Use sp::indexing::checks::neighborhood_exists to make sure that you use it right.
  */
-Pixel neighbor_by_index(
+struct Pixel neighbor_by_index(
     struct Pixel pixel,
     ULONG neighbor_index
 );

--- a/include/indexing_checks.hpp
+++ b/include/indexing_checks.hpp
@@ -57,7 +57,7 @@ using sp::types::ULONG;
  * are not a neighbors in the sp::graph::disparity::DisparityGraph.
  */
 bool neighborhood_exists(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     struct Pixel neighbor
 );
@@ -73,7 +73,7 @@ bool neighborhood_exists(
  * calculated by sp::indexing::neighbor_index function.
  */
 bool neighborhood_exists_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     ULONG neighbor_index
 );
@@ -89,7 +89,7 @@ bool neighborhood_exists_fast(
  * the maximal allowed.
  */
 bool node_exists(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node
 );
 
@@ -101,7 +101,7 @@ bool node_exists(
  * of the neighboring pixels.
  */
 bool edge_exists(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 );
 

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -52,7 +52,7 @@ using sp::types::Pixel;
  * The output is sorted in ascending order.
  */
 FLOAT_ARRAY fetch_pixel_available_penalties(
-    const DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     FLOAT minimal_penalty
 );
@@ -63,7 +63,7 @@ FLOAT_ARRAY fetch_pixel_available_penalties(
  * The output is sorted in ascending order.
  */
 FLOAT_ARRAY fetch_edge_available_penalties(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge,
     FLOAT minimal_penalty
 );
@@ -74,7 +74,7 @@ FLOAT_ARRAY fetch_edge_available_penalties(
  * The output is sorted in ascending order.
  */
 FLOAT_ARRAY fetch_available_penalties(
-    const struct LowestPenalties& lowest_penalties
+    const struct LowestPenalties* lowest_penalties
 );
 /**
  * \brief Calculate the minimal threshold
@@ -122,8 +122,8 @@ FLOAT_ARRAY fetch_available_penalties(
  * not more than \f$ \left[ \log_2 \ell + 1 \right] \f$ times.
  */
 FLOAT calculate_minimal_consistent_threshold(
-    const struct LowestPenalties& lowest_penalties,
-    const struct DisparityGraph& disparity_graph,
+    const struct LowestPenalties* lowest_penalties,
+    const struct DisparityGraph* disparity_graph,
     FLOAT_ARRAY available_penalties
 );
 /**
@@ -162,7 +162,7 @@ struct ConstraintGraph* find_labeling(struct ConstraintGraph* graph);
  * to the output image.
  */
 struct Image build_disparity_map(
-    const struct ConstraintGraph& constraint_graph
+    const struct ConstraintGraph* constraint_graph
 );
 
 }

--- a/include/lowest_penalties.hpp
+++ b/include/lowest_penalties.hpp
@@ -77,7 +77,7 @@ struct LowestPenalties
      * \brief The sp::graph::disparity::DisparityGraph
      * for which the lowest penalties should be calculated.
      */
-    const struct DisparityGraph& graph;
+    const struct DisparityGraph* graph;
     /**
      * \brief Minimal penalties of nodes per pixels.
      *
@@ -116,13 +116,13 @@ struct LowestPenalties
      * after sp::graph::lowest_penalties::LowestPenalties construction,
      * the sp::graph::lowest_penalties::LowestPenalties instance will not be changed.
      */
-    explicit LowestPenalties(const struct DisparityGraph& graph);
+    explicit LowestPenalties(const struct DisparityGraph* graph);
 };
 /**
  * \brief Calculate minimal penalty among nodes of a pixel.
  */
 FLOAT calculate_lowest_pixel_penalty(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel
 );
 /**
@@ -132,7 +132,7 @@ FLOAT calculate_lowest_pixel_penalty(
  * Use sp::indexing::checks::neighborhood_exists to make sure that you use it right.
  */
 FLOAT calculate_lowest_neighborhood_penalty(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     struct Pixel neighbor
 );
@@ -143,7 +143,7 @@ FLOAT calculate_lowest_neighborhood_penalty(
  * Use sp::indexing::checks::neighborhood_exists_fast to make sure that you use it right.
  */
 FLOAT calculate_lowest_neighborhood_penalty_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 );
 /**
@@ -153,7 +153,7 @@ FLOAT calculate_lowest_neighborhood_penalty_fast(
  * Use sp::indexing::checks::edge_exists to make sure that you use it right.
  */
 FLOAT calculate_lowest_neighborhood_penalty_slow(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     ULONG neighbor_index
 );
@@ -165,7 +165,7 @@ FLOAT calculate_lowest_neighborhood_penalty_slow(
  * Use sp::indexing::checks::neighborhood_exists to make sure that you use it right.
  */
 FLOAT lowest_pixel_penalty(
-    const struct LowestPenalties& penalties,
+    const struct LowestPenalties* penalties,
     struct Pixel pixel
 );
 /**
@@ -177,7 +177,7 @@ FLOAT lowest_pixel_penalty(
  * Use sp::indexing::checks::neighborhood_exists_fast to make sure that you use it right.
  */
 FLOAT lowest_neighborhood_penalty_fast(
-    const struct LowestPenalties& penalties,
+    const struct LowestPenalties* penalties,
     struct Pixel pixel,
     struct Pixel neighbor
 );
@@ -190,7 +190,7 @@ FLOAT lowest_neighborhood_penalty_fast(
  * Use sp::indexing::checks::edge_exists to make sure that you use it right.
  */
 FLOAT lowest_neighborhood_penalty(
-    const struct LowestPenalties& penalties,
+    const struct LowestPenalties* penalties,
     struct Edge edge
 );
 

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -67,6 +67,9 @@ using BOOL = bool;
  */
 using BOOL_ARRAY = std::vector<BOOL>;
 
+const BOOL TRUE = true;
+const BOOL FALSE = false;
+
 /**
  * Structure that contains position of a pixel.
  */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -96,7 +96,7 @@ if (OpenMP_CXX_FOUND)
         constraint_graph
         OpenMP::OpenMP_CXX
     )
-endif(OpenMP_CXX_FOUND)
+endif (OpenMP_CXX_FOUND)
 target_link_libraries(
     labeling_finder
     constraint_graph

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -57,11 +57,11 @@ DisparityGraph::DisparityGraph(
     , cleanness{cleanness}
     , smoothness{smoothness}
 {
-    if (!image_valid(this->left))
+    if (!image_valid(&(this->left)))
     {
         throw std::invalid_argument("Left image is invalid.");
     }
-    if (!image_valid(this->right))
+    if (!image_valid(&(this->right)))
     {
         throw std::invalid_argument("Right image is invalid.");
     }
@@ -163,22 +163,24 @@ DisparityGraph::DisparityGraph(
     );
 }
 
-FLOAT edge_penalty(const struct DisparityGraph& graph, struct Edge edge)
+FLOAT edge_penalty(const struct DisparityGraph* graph, struct Edge edge)
 {
     return
-        graph.smoothness
+        graph->smoothness
         * SQR(TO_FLOAT(edge.node.disparity) - TO_FLOAT(edge.neighbor.disparity))
         - reparametrization_value_slow(graph, edge)
         - reparametrization_value(graph, edge.neighbor, edge.node.pixel);
 }
 
-FLOAT node_penalty(const struct DisparityGraph& graph, struct Node node)
+FLOAT node_penalty(const struct DisparityGraph* graph, struct Node node)
 {
-    Pixel left_pixel{node.pixel.x + node.disparity, node.pixel.y};
+    struct Pixel left_pixel;
+    left_pixel.x = node.pixel.x + node.disparity;
+    left_pixel.y = node.pixel.y;
     return
-        graph.cleanness
-        * SQR(TO_FLOAT(pixel_value(graph.right, node.pixel))
-            - TO_FLOAT(pixel_value(graph.left, left_pixel)))
+        graph->cleanness
+        * SQR(TO_FLOAT(pixel_value(&(graph->right), node.pixel))
+            - TO_FLOAT(pixel_value(&(graph->left), left_pixel)))
         + reparametrization_value_fast(graph, node, 0)
         + reparametrization_value_fast(graph, node, 1)
         + reparametrization_value_fast(graph, node, 2)

--- a/lib/image.cpp
+++ b/lib/image.cpp
@@ -26,15 +26,15 @@
 namespace sp::image
 {
 
-bool image_valid(const struct Image& image)
+BOOL image_valid(const struct Image* image)
 {
-    if (image.max_value == 0 || image.width == 0 || image.height == 0)
+    if (image->max_value == 0 || image->width == 0 || image->height == 0)
     {
         return false;
     }
-    for (unsigned i = 0; i < image.width * image.height; ++i)
+    for (unsigned i = 0; i < image->width * image->height; ++i)
     {
-        if (image.data[i] > image.max_value)
+        if (image->data[i] > image->max_value)
         {
             return false;
         }

--- a/lib/indexing.cpp
+++ b/lib/indexing.cpp
@@ -29,14 +29,14 @@ namespace sp::indexing
 
 using sp::graph::disparity::NEIGHBORS_COUNT;
 
-ULONG pixel_index(const struct Image& image, struct Pixel pixel)
+ULONG pixel_index(const struct Image* image, struct Pixel pixel)
 {
-    return image.width * pixel.y + pixel.x;
+    return image->width * pixel.y + pixel.x;
 }
 
-ULONG pixel_value(const struct Image& image, struct Pixel pixel)
+ULONG pixel_value(const struct Image* image, struct Pixel pixel)
 {
-    return image.data[pixel_index(image, pixel)];
+    return image->data[pixel_index(image, pixel)];
 }
 
 ULONG neighbor_index(
@@ -68,26 +68,26 @@ ULONG neighbor_index(
 }
 
 ULONG reparametrization_index_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     ULONG neighbor_index
 )
 {
     ULONG index = 0;
-    index *= graph.right.width;
+    index *= graph->right.width;
     index += node.pixel.x;
     index *= NEIGHBORS_COUNT;
     index += neighbor_index;
-    index *= graph.disparity_levels;
+    index *= graph->disparity_levels;
     index += node.disparity;
-    index *= graph.left.height;
+    index *= graph->left.height;
     index += node.pixel.y;
 
     return index;
 }
 
 ULONG reparametrization_index(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     struct Pixel neighbor
 )
@@ -100,7 +100,7 @@ ULONG reparametrization_index(
 }
 
 ULONG reparametrization_index_slow(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 )
 {
@@ -112,51 +112,51 @@ ULONG reparametrization_index_slow(
 }
 
 FLOAT reparametrization_value(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     struct Pixel neighbor
 )
 {
-    return graph.reparametrization[reparametrization_index(graph, node, neighbor)];
+    return graph->reparametrization[reparametrization_index(graph, node, neighbor)];
 }
 
 FLOAT reparametrization_value_slow(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 )
 {
-    return graph.reparametrization[reparametrization_index_slow(graph, edge)];
+    return graph->reparametrization[reparametrization_index_slow(graph, edge)];
 }
 
 FLOAT reparametrization_value_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node,
     ULONG neighbor_index
 )
 {
-    return graph.reparametrization[
+    return graph->reparametrization[
         reparametrization_index_fast(graph, node, neighbor_index)
     ];
 }
 
-ULONG node_index(const struct DisparityGraph& graph, struct Node node)
+ULONG node_index(const struct DisparityGraph* graph, struct Node node)
 {
-    return node.disparity + graph.disparity_levels
-        * (node.pixel.y + graph.right.height * node.pixel.x);
+    return node.disparity + graph->disparity_levels
+        * (node.pixel.y + graph->right.height * node.pixel.x);
 }
 
 ULONG neighborhood_index_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     ULONG neighbor_index
 )
 {
     return neighbor_index
-        + NEIGHBORS_COUNT * (pixel.y + graph.right.height * pixel.x);
+        + NEIGHBORS_COUNT * (pixel.y + graph->right.height * pixel.x);
 }
 
 ULONG neighborhood_index(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     struct Pixel neighbor
 )
@@ -169,7 +169,7 @@ ULONG neighborhood_index(
 }
 
 ULONG neighborhood_index_slow(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 )
 {
@@ -180,7 +180,7 @@ ULONG neighborhood_index_slow(
     );
 }
 
-Pixel neighbor_by_index(
+struct Pixel neighbor_by_index(
     struct Pixel pixel,
     ULONG neighbor_index
 )

--- a/lib/indexing_checks.cpp
+++ b/lib/indexing_checks.cpp
@@ -30,7 +30,7 @@ namespace sp::indexing::checks
 using sp::types::FLOAT;
 
 bool neighborhood_exists(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     struct Pixel neighbor
 )
@@ -43,36 +43,36 @@ bool neighborhood_exists(
 }
 
 bool neighborhood_exists_fast(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Pixel pixel,
     ULONG neighbor_index
 )
 {
     return !(neighbor_index > 3
-        || pixel.y >= graph.right.height
-        || pixel.x >= graph.right.width
-        || (pixel.x + 1 == graph.left.width && neighbor_index == 0)
+        || pixel.y >= graph->right.height
+        || pixel.x >= graph->right.width
+        || (pixel.x + 1 == graph->left.width && neighbor_index == 0)
         || (pixel.x == 0 && neighbor_index == 1)
-        || (pixel.y + 1 == graph.left.height && neighbor_index == 2)
+        || (pixel.y + 1 == graph->left.height && neighbor_index == 2)
         || (pixel.y == 0 && neighbor_index == 3)
     );
 }
 
 bool node_exists(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Node node
 )
 {
     return !(
-        node.disparity >= graph.disparity_levels
-        || node.pixel.y >= graph.right.height
-        || node.pixel.x >= graph.right.width
-        || node.pixel.x + node.disparity >= graph.left.width
+        node.disparity >= graph->disparity_levels
+        || node.pixel.y >= graph->right.height
+        || node.pixel.x >= graph->right.width
+        || node.pixel.x + node.disparity >= graph->left.width
     );
 }
 
 bool edge_exists(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge
 )
 {

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -302,8 +302,6 @@ struct ConstraintGraph* find_labeling(
     struct ConstraintGraph* graph
 )
 {
-    build_csp_program(&problem);
-    prepare_problem(graph, &problem);
     for (ULONG x = 0; x < graph->disparity_graph->left.width; ++x)
     {
         for (ULONG y = 0; y < graph->disparity_graph->left.height; ++y)

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -305,11 +305,8 @@ struct ConstraintGraph* find_labeling(
     struct gpu::Problem problem;
     build_csp_program(&problem);
     prepare_problem(graph, &problem);
-    gpu::csp_solution_iteration_gpu(graph, &problem);
-    /*
     for (ULONG x = 0; x < graph->disparity_graph->left.width; ++x)
     {
-        std::cout << "Process column " << x;
         for (ULONG y = 0; y < graph->disparity_graph->left.height; ++y)
         {
             if (choose_best_node(graph, {x, y}) == nullptr)

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -49,17 +49,17 @@ using std::to_string;
 using std::unique;
 
 FLOAT_ARRAY fetch_pixel_available_penalties(
-    const DisparityGraph& graph,
+    const DisparityGraph* graph,
     struct Pixel pixel,
     FLOAT minimal_penalty
 )
 {
     FLOAT_ARRAY result(
-        pixel.x + graph.disparity_levels < graph.left.width + 1
-        ? graph.disparity_levels
-        : graph.left.width - pixel.x
+        pixel.x + graph->disparity_levels < graph->left.width + 1
+        ? graph->disparity_levels
+        : graph->left.width - pixel.x
     );
-    Node node{pixel, 0};
+    struct Node node{pixel, 0};
     for (
         node.disparity = 0;
         node.disparity < result.size();
@@ -80,7 +80,7 @@ FLOAT_ARRAY fetch_pixel_available_penalties(
 }
 
 FLOAT_ARRAY fetch_edge_available_penalties(
-    const struct DisparityGraph& graph,
+    const struct DisparityGraph* graph,
     struct Edge edge,
     FLOAT minimal_penalty
 )
@@ -90,8 +90,8 @@ FLOAT_ARRAY fetch_edge_available_penalties(
     ULONG initial_disparity = 0;
     for (
         edge.node.disparity = 0;
-        edge.node.pixel.x + edge.node.disparity < graph.left.width
-            && edge.node.disparity < graph.disparity_levels;
+        edge.node.pixel.x + edge.node.disparity < graph->left.width
+            && edge.node.disparity < graph->disparity_levels;
         ++edge.node.disparity
     )
     {
@@ -108,8 +108,8 @@ FLOAT_ARRAY fetch_edge_available_penalties(
         }
         for (
             edge.neighbor.disparity = initial_disparity;
-            edge.neighbor.pixel.x + edge.neighbor.disparity < graph.left.width
-                && edge.neighbor.disparity < graph.disparity_levels;
+            edge.neighbor.pixel.x + edge.neighbor.disparity < graph->left.width
+                && edge.neighbor.disparity < graph->disparity_levels;
             ++edge.neighbor.disparity
         )
         {
@@ -125,22 +125,22 @@ FLOAT_ARRAY fetch_edge_available_penalties(
 }
 
 FLOAT_ARRAY fetch_available_penalties(
-    const struct LowestPenalties& lowest_penalties
+    const struct LowestPenalties* lowest_penalties
 )
 {
     FLOAT_ARRAY result;
     FLOAT_ARRAY result_;
     FLOAT_ARRAY available_penalties;
     struct Pixel pixel{0, 0};
-    for (pixel.x = 0; pixel.x < lowest_penalties.graph.right.width; ++pixel.x)
+    for (pixel.x = 0; pixel.x < lowest_penalties->graph->right.width; ++pixel.x)
     {
         for (
             pixel.y = 0;
-            pixel.y < lowest_penalties.graph.right.height;
+            pixel.y < lowest_penalties->graph->right.height;
             ++pixel.y)
         {
             available_penalties = fetch_pixel_available_penalties(
-                lowest_penalties.graph,
+                lowest_penalties->graph,
                 pixel,
                 lowest_pixel_penalty(lowest_penalties, pixel)
             );
@@ -167,7 +167,7 @@ FLOAT_ARRAY fetch_available_penalties(
             {
                 if (
                     !neighborhood_exists_fast(
-                        lowest_penalties.graph, pixel, neighbor_index
+                        lowest_penalties->graph, pixel, neighbor_index
                     )
                 )
                 {
@@ -178,7 +178,7 @@ FLOAT_ARRAY fetch_available_penalties(
                     {neighbor_by_index(pixel, neighbor_index), 0}
                 };
                 available_penalties = fetch_edge_available_penalties(
-                    lowest_penalties.graph,
+                    lowest_penalties->graph,
                     edge,
                     lowest_neighborhood_penalty(
                         lowest_penalties,
@@ -206,8 +206,8 @@ FLOAT_ARRAY fetch_available_penalties(
 }
 
 FLOAT calculate_minimal_consistent_threshold(
-    const struct LowestPenalties& lowest_penalties,
-    const struct DisparityGraph& disparity_graph,
+    const struct LowestPenalties* lowest_penalties,
+    const struct DisparityGraph* disparity_graph,
     FLOAT_ARRAY available_penalties
 )
 {
@@ -242,16 +242,18 @@ struct ConstraintGraph* choose_best_node(
     struct Pixel pixel
 )
 {
-    Node node{pixel, 0};
+    struct Node node;
+    node.pixel = pixel;
+    node.disparity = 0;
     FLOAT minimal_penalty = -1;
     for (
         node.disparity = 0;
-        node.pixel.x + node.disparity < graph->disparity_graph.left.width
-            && node.disparity < graph->disparity_graph.disparity_levels;
+        node.pixel.x + node.disparity < graph->disparity_graph->left.width
+            && node.disparity < graph->disparity_graph->disparity_levels;
         ++node.disparity
     )
     {
-        if (!is_node_available(*graph, node))
+        if (!is_node_available(graph, node))
         {
             continue;
         }
@@ -271,12 +273,12 @@ struct ConstraintGraph* choose_best_node(
     bool node_chosen = false;
     for (
         node.disparity = 0;
-        node.pixel.x + node.disparity < graph->disparity_graph.left.width
-            && node.disparity < graph->disparity_graph.disparity_levels;
+        node.pixel.x + node.disparity < graph->disparity_graph->left.width
+            && node.disparity < graph->disparity_graph->disparity_levels;
         ++node.disparity
     )
     {
-        if (!is_node_available(*graph, node))
+        if (!is_node_available(graph, node))
         {
             continue;
         }
@@ -293,16 +295,22 @@ struct ConstraintGraph* choose_best_node(
             node_chosen = true;
         }
     }
-    return node_chosen? graph : nullptr;
+    return node_chosen? graph : NULL;
 }
 
 struct ConstraintGraph* find_labeling(
     struct ConstraintGraph* graph
 )
 {
-    for (ULONG x = 0; x < graph->disparity_graph.left.width; ++x)
+    struct gpu::Problem problem;
+    build_csp_program(&problem);
+    prepare_problem(graph, &problem);
+    gpu::csp_solution_iteration_gpu(graph, &problem);
+    /*
+    for (ULONG x = 0; x < graph->disparity_graph->left.width; ++x)
     {
-        for (ULONG y = 0; y < graph->disparity_graph.left.height; ++y)
+        std::cout << "Process column " << x;
+        for (ULONG y = 0; y < graph->disparity_graph->left.height; ++y)
         {
             if (choose_best_node(graph, {x, y}) == nullptr)
             {
@@ -318,36 +326,40 @@ struct ConstraintGraph* find_labeling(
 }
 
 struct Image build_disparity_map(
-    const struct ConstraintGraph& constraint_graph
+    const struct ConstraintGraph* constraint_graph
 )
 {
     struct Image result{
-        constraint_graph.disparity_graph.left.width,
-        constraint_graph.disparity_graph.left.height,
-        constraint_graph.disparity_graph.disparity_levels,
+        constraint_graph->disparity_graph->left.width,
+        constraint_graph->disparity_graph->left.height,
+        constraint_graph->disparity_graph->disparity_levels,
         ULONG_ARRAY(
-            constraint_graph.disparity_graph.left.height
-            * constraint_graph.disparity_graph.left.width
+            constraint_graph->disparity_graph->left.height
+            * constraint_graph->disparity_graph->left.width
         )
     };
-    Node node{{0, 0}, 0};
+    struct Node node;
+    node.pixel.x = 0;
+    node.pixel.y = 0;
+    node.disparity = 0;
+
     BOOL found = false;
     for (
         node.pixel.x = 0;
-        node.pixel.x < constraint_graph.disparity_graph.left.width;
+        node.pixel.x < constraint_graph->disparity_graph->left.width;
         ++node.pixel.x)
     {
         for (
             node.pixel.y = 0;
-            node.pixel. y < constraint_graph.disparity_graph.left.height;
+            node.pixel. y < constraint_graph->disparity_graph->left.height;
             ++node.pixel.y)
         {
             for (
                 node.disparity = 0;
                 node.pixel.x + node.disparity
-                    < constraint_graph.disparity_graph.left.width
+                    < constraint_graph->disparity_graph->left.width
                 && node.disparity
-                    < constraint_graph.disparity_graph.disparity_levels;
+                    < constraint_graph->disparity_graph->disparity_levels;
                 ++node.disparity
             )
             {
@@ -363,7 +375,7 @@ struct Image build_disparity_map(
                             + ">."
                         );
                     }
-                    result.data[pixel_index(result, node.pixel)]
+                    result.data[pixel_index(&result, node.pixel)]
                         = node.disparity;
                     found = true;
                     break;

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -302,7 +302,6 @@ struct ConstraintGraph* find_labeling(
     struct ConstraintGraph* graph
 )
 {
-    struct gpu::Problem problem;
     build_csp_program(&problem);
     prepare_problem(graph, &problem);
     for (ULONG x = 0; x < graph->disparity_graph->left.width; ++x)

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -105,20 +105,20 @@ int main(int argc, char* argv[]) try
                 smoothness
             };
             struct sp::graph::lowest_penalties::LowestPenalties
-                lowest_penalties{disparity_graph};
+                lowest_penalties{&disparity_graph};
             auto available_penalties
                 = sp::labeling::finder::fetch_available_penalties(
-                    lowest_penalties
+                    &lowest_penalties
                 );
             sp::types::FLOAT threshold
                 = sp::labeling::finder::calculate_minimal_consistent_threshold(
-                    lowest_penalties,
-                    disparity_graph,
+                    &lowest_penalties,
+                    &disparity_graph,
                     available_penalties
                 );
             struct sp::graph::constraint::ConstraintGraph constraint_graph{
-                disparity_graph,
-                lowest_penalties,
+                &disparity_graph,
+                &lowest_penalties,
                 threshold
             };
             if (!solve_csp(&constraint_graph))
@@ -144,7 +144,7 @@ int main(int argc, char* argv[]) try
             std::shared_ptr<struct sp::image::Image> result
                 = std::make_shared<struct sp::image::Image>(
                     sp::labeling::finder::build_disparity_map(
-                        constraint_graph
+                        &constraint_graph
                     ));
             std::ofstream image_file(vm["output-image"].as<std::string>());
             sp::image::PGM_IO pgm_io{result};

--- a/lib/pgm_io.cpp
+++ b/lib/pgm_io.cpp
@@ -110,7 +110,7 @@ bool PGM_IO::check_file_end(istream& in)
 
 ostream& operator<<(ostream& out, const PGM_IO& ppm_io)
 {
-    if (!ppm_io.get_image() || !image_valid(*ppm_io.get_image()))
+    if (!ppm_io.get_image() || !image_valid(ppm_io.get_image().get()))
     {
         return out;
     }
@@ -122,7 +122,7 @@ ostream& operator<<(ostream& out, const PGM_IO& ppm_io)
     {
         for (ULONG x = 0; x < image->width; ++x)
         {
-            out << image->data[pixel_index(*image, {x, y})];
+            out << image->data[pixel_index(image.get(), {x, y})];
             if (x == 0 || (x + 1) % PGM_IO::MAX_NUMBERS_PER_ROW != 0)
             {
                 if (x + 1 < image->width)
@@ -180,7 +180,7 @@ istream& operator>>(istream& in, PGM_IO& ppm_io)
         {
             try
             {
-                image->data[pixel_index(*image, {x, y})] =
+                image->data[pixel_index(image.get(), {x, y})] =
                     stoul(PGM_IO::read_pgm_instruction(in));
             }
             catch (invalid_argument&)

--- a/tests/constraint_graph.cpp
+++ b/tests/constraint_graph.cpp
@@ -56,8 +56,8 @@ BOOST_AUTO_TEST_CASE(check_nodes_indexing)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
-    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 1};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
+    struct ConstraintGraph constraint_graph{&disparity_graph, &lowest_penalties, 1};
 
     BOOST_CHECK_EQUAL(node_index(constraint_graph.disparity_graph, {{0, 0}, 0}), 0);
     BOOST_CHECK_EQUAL(node_index(constraint_graph.disparity_graph, {{0, 0}, 2}), 2);
@@ -82,8 +82,8 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
-    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 1};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
+    struct ConstraintGraph constraint_graph{&disparity_graph, &lowest_penalties, 1};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 1, 1);
 
     struct Node node{{0, 0}, 0};
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
             )
             {
                 BOOST_CHECK_EQUAL(
-                    is_node_available(constraint_graph, node),
+                    is_node_available(&constraint_graph, node),
                     node.pixel.x + node.disparity
                     < disparity_graph.left.width
                 );
@@ -131,27 +131,27 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
-    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 128 * 128};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
+    struct ConstraintGraph constraint_graph{&disparity_graph, &lowest_penalties, 128 * 128};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 128 * 128, 1);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 0, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 0}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 0}), 0, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 0}, 0}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 127 * 127, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 0}, 1}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 1}), 127 * 127, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 0}, 1}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 2}), 256 * 256, 1);
-    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 0}, 2}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 2}), 256 * 256, 1);
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{0, 0}, 2}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 0}), 0, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 1}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 1}, 0}), 0, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 1}, 0}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 1}), 129 * 129, 1);
-    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 1}, 1}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 1}, 1}), 129 * 129, 1);
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{0, 1}, 1}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 2}), 256 * 256, 1);
-    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 1}, 2}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 1}, 2}), 256 * 256, 1);
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{0, 1}, 2}));
 }
 
 BOOST_AUTO_TEST_CASE(check_disparity_loop)
@@ -181,15 +181,15 @@ BOOST_AUTO_TEST_CASE(check_disparity_loop)
     struct Image right_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, right_image, 2, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
-    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 15};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
+    struct ConstraintGraph constraint_graph{&disparity_graph, &lowest_penalties, 15};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 15, 1);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 4, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 0}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 0}), 4, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 0}, 0}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 9, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 0}, 1}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 1}), 9, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 0}, 1}));
 }
 
 /**
@@ -230,12 +230,12 @@ BOOST_AUTO_TEST_CASE(check_minimal_node_value_calculation)
     struct Image right_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
-    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 0.5};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
+    struct ConstraintGraph constraint_graph{&disparity_graph, &lowest_penalties, 0.5};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 0.5, 1);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{2, 0}, 0}), 1, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{2, 0}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{2, 0}, 0}), 1, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{2, 0}, 0}));
 }
 
 BOOST_AUTO_TEST_CASE(check_removal)
@@ -265,35 +265,35 @@ BOOST_AUTO_TEST_CASE(check_removal)
     struct Image right_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
-    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 16};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
+    struct ConstraintGraph constraint_graph{&disparity_graph, &lowest_penalties, 16};
 
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 16, 1);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 36, 1);
-    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 0}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 0}), 36, 1);
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{0, 0}, 0}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 25, 1);
-    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 0}, 1}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 1}), 25, 1);
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{0, 0}, 1}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 2}), 0, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 0}, 2}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 2}), 0, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 0}, 2}));
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 4, 1);
-    BOOST_CHECK(is_node_available(constraint_graph, {{1, 0}, 0}));
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{1, 0}, 0}), 4, 1);
+    BOOST_CHECK(is_node_available(&constraint_graph, {{1, 0}, 0}));
 
     BOOST_CHECK(solve_csp(&constraint_graph));
 
-    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 0}, 0}));
-    BOOST_CHECK(!is_node_available(constraint_graph, {{0, 0}, 1}));
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 0}, 2}));
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{0, 0}, 0}));
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{0, 0}, 1}));
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 0}, 2}));
 
-    BOOST_CHECK(!is_node_available(constraint_graph, {{1, 0}, 0}));
-    BOOST_CHECK(is_node_available(constraint_graph, {{1, 0}, 1}));
+    BOOST_CHECK(!is_node_available(&constraint_graph, {{1, 0}, 0}));
+    BOOST_CHECK(is_node_available(&constraint_graph, {{1, 0}, 1}));
 
-    BOOST_CHECK(!is_edge_available(constraint_graph, {{{0, 0}, 0}, {{1, 0}, 0}}));
-    BOOST_CHECK(!is_edge_available(constraint_graph, {{{0, 0}, 1}, {{1, 0}, 0}}));
-    BOOST_CHECK(!is_edge_available(constraint_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
+    BOOST_CHECK(!is_edge_available(&constraint_graph, {{{0, 0}, 0}, {{1, 0}, 0}}));
+    BOOST_CHECK(!is_edge_available(&constraint_graph, {{{0, 0}, 1}, {{1, 0}, 0}}));
+    BOOST_CHECK(!is_edge_available(&constraint_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
 }
 
 BOOST_AUTO_TEST_CASE(check_unconstrained_disparities)
@@ -313,8 +313,8 @@ BOOST_AUTO_TEST_CASE(check_unconstrained_disparities)
     struct Image left_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, left_image, 4, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
-    struct ConstraintGraph constraint_graph{disparity_graph, lowest_penalties, 9};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
+    struct ConstraintGraph constraint_graph{&disparity_graph, &lowest_penalties, 9};
     BOOST_CHECK_CLOSE(constraint_graph.threshold, 9, 1);
     BOOST_CHECK(solve_csp(&constraint_graph));
 
@@ -331,10 +331,10 @@ BOOST_AUTO_TEST_CASE(check_unconstrained_disparities)
     make_node_unavailable(&constraint_graph, {{1, 2}, 1});
 
     BOOST_CHECK(solve_csp(&constraint_graph));
-    BOOST_CHECK(is_node_available(constraint_graph, {{0, 0}, 0}));
-    BOOST_CHECK(is_node_available(constraint_graph, {{1, 0}, 2}));
-    BOOST_CHECK(is_node_available(constraint_graph, {{2, 0}, 1}));
-    BOOST_CHECK(is_node_available(constraint_graph, {{1, 1}, 0}));
+    BOOST_CHECK(is_node_available(&constraint_graph, {{0, 0}, 0}));
+    BOOST_CHECK(is_node_available(&constraint_graph, {{1, 0}, 2}));
+    BOOST_CHECK(is_node_available(&constraint_graph, {{2, 0}, 1}));
+    BOOST_CHECK(is_node_available(&constraint_graph, {{1, 1}, 0}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/disparity_graph.cpp
+++ b/tests/disparity_graph.cpp
@@ -59,21 +59,21 @@ BOOST_AUTO_TEST_CASE(check_nodes_existence)
 
     for (ULONG y = 0; y < 2; ++y)
     {
-        BOOST_CHECK(node_exists(disparity_graph, {{0, y}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{1, y}, 0}));
-        BOOST_CHECK(node_exists(disparity_graph, {{2, y}, 0}));
+        BOOST_CHECK(node_exists(&disparity_graph, {{0, y}, 0}));
+        BOOST_CHECK(node_exists(&disparity_graph, {{1, y}, 0}));
+        BOOST_CHECK(node_exists(&disparity_graph, {{2, y}, 0}));
 
-        BOOST_CHECK(node_exists(disparity_graph, {{0, y}, 1}));
-        BOOST_CHECK(node_exists(disparity_graph, {{1, y}, 1}));
+        BOOST_CHECK(node_exists(&disparity_graph, {{0, y}, 1}));
+        BOOST_CHECK(node_exists(&disparity_graph, {{1, y}, 1}));
 
-        BOOST_CHECK(!node_exists(disparity_graph, {{0, y}, 2}));
-        BOOST_CHECK(!node_exists(disparity_graph, {{1, y}, 2}));
+        BOOST_CHECK(!node_exists(&disparity_graph, {{0, y}, 2}));
+        BOOST_CHECK(!node_exists(&disparity_graph, {{1, y}, 2}));
 
-        BOOST_CHECK(!node_exists(disparity_graph, {{2, y}, 1}));
+        BOOST_CHECK(!node_exists(&disparity_graph, {{2, y}, 1}));
     }
-    BOOST_CHECK(!node_exists(disparity_graph, {{0, 2}, 0}));
-    BOOST_CHECK(!node_exists(disparity_graph, {{3, 0}, 2}));
-    BOOST_CHECK(!node_exists(disparity_graph, {{3, 2}, 2}));
+    BOOST_CHECK(!node_exists(&disparity_graph, {{0, 2}, 0}));
+    BOOST_CHECK(!node_exists(&disparity_graph, {{3, 0}, 2}));
+    BOOST_CHECK(!node_exists(&disparity_graph, {{3, 2}, 2}));
 }
 
 BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
@@ -93,22 +93,22 @@ BOOST_AUTO_TEST_CASE(check_reparametrization_indexing)
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
 
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 0), 0);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 0), 1);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 1}, 0), 2);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 2}, 0), 4);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 2}, 0), 5);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 1), 6);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 0}, 1), 7);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 1}, 1), 8);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 1}, 1), 9);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 2}, 1), 10);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 2}, 1), 11);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 2), 12);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 0}, 0}, 3), 18);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{0, 1}, 2}, 3), 23);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 0}, 0}, 0), 24);
-    BOOST_CHECK_EQUAL(reparametrization_index_fast(disparity_graph, {{1, 1}, 2}, 3), 47);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 0}, 0), 0);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 1}, 0}, 0), 1);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 1}, 0), 2);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 2}, 0), 4);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 1}, 2}, 0), 5);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 0}, 1), 6);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 1}, 0}, 1), 7);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 1}, 1), 8);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 1}, 1}, 1), 9);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 2}, 1), 10);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 1}, 2}, 1), 11);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 0}, 2), 12);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 0}, 0}, 3), 18);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{0, 1}, 2}, 3), 23);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{1, 0}, 0}, 0), 24);
+    BOOST_CHECK_EQUAL(reparametrization_index_fast(&disparity_graph, {{1, 1}, 2}, 3), 47);
 }
 
 BOOST_AUTO_TEST_CASE(check_neighborhood)
@@ -139,22 +139,22 @@ BOOST_AUTO_TEST_CASE(check_neighborhood)
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {1, 0}));
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {0, 0}, {0, 1}));
+    BOOST_CHECK(neighborhood_exists(&disparity_graph, {0, 0}, {1, 0}));
+    BOOST_CHECK(neighborhood_exists(&disparity_graph, {0, 0}, {0, 1}));
 
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {1, 0}, {2, 0}));
+    BOOST_CHECK(neighborhood_exists(&disparity_graph, {1, 0}, {2, 0}));
 
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {1, 0}, {0, 0}));
-    BOOST_CHECK(neighborhood_exists(disparity_graph, {1, 0}, {1, 1}));
+    BOOST_CHECK(neighborhood_exists(&disparity_graph, {1, 0}, {0, 0}));
+    BOOST_CHECK(neighborhood_exists(&disparity_graph, {1, 0}, {1, 1}));
 
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {0, 0}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {1, 1}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {0, 2}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {0, 0}, {2, 0}));
+    BOOST_CHECK(!neighborhood_exists(&disparity_graph, {0, 0}, {0, 0}));
+    BOOST_CHECK(!neighborhood_exists(&disparity_graph, {0, 0}, {1, 1}));
+    BOOST_CHECK(!neighborhood_exists(&disparity_graph, {0, 0}, {0, 2}));
+    BOOST_CHECK(!neighborhood_exists(&disparity_graph, {0, 0}, {2, 0}));
 
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {1, 0}, {1, 0}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {1, 0}, {0, 1}));
-    BOOST_CHECK(!neighborhood_exists(disparity_graph, {1, 0}, {2, 1}));
+    BOOST_CHECK(!neighborhood_exists(&disparity_graph, {1, 0}, {1, 0}));
+    BOOST_CHECK(!neighborhood_exists(&disparity_graph, {1, 0}, {0, 1}));
+    BOOST_CHECK(!neighborhood_exists(&disparity_graph, {1, 0}, {2, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(check_edges_existence)
@@ -185,17 +185,17 @@ BOOST_AUTO_TEST_CASE(check_edges_existence)
 
     struct DisparityGraph disparity_graph{left_image, right_image, 2, 1, 1};
 
-    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}));
-    BOOST_CHECK(edge_exists(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}));
+    BOOST_CHECK(edge_exists(&disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}));
+    BOOST_CHECK(edge_exists(&disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}));
 
-    BOOST_CHECK(edge_exists(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 0}}));
-    BOOST_CHECK(edge_exists(disparity_graph, {{{1, 0}, 1}, {{0, 0}, 0}}));
+    BOOST_CHECK(edge_exists(&disparity_graph, {{{1, 0}, 0}, {{0, 0}, 0}}));
+    BOOST_CHECK(edge_exists(&disparity_graph, {{{1, 0}, 1}, {{0, 0}, 0}}));
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 2}, {{1, 0}, 1}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 1}, {{1, 0}, 2}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{1, 0}, 2}, {{1, 0}, 1}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{0, 0}, 1}, {{1, 0}, 2}}));
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 0}, {{1, 0}, 2}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{1, 0}, 0}, {{1, 0}, 2}}));
 }
 
 BOOST_AUTO_TEST_CASE(check_continuity_constraint)
@@ -226,11 +226,11 @@ BOOST_AUTO_TEST_CASE(check_continuity_constraint)
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 2}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{0, 0}, 2}, {{1, 0}, 0}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{1, 0}, 0}, {{0, 0}, 2}}));
 
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{0, 1}, 2}, {{1, 1}, 0}}));
-    BOOST_CHECK(!edge_exists(disparity_graph, {{{1, 1}, 0}, {{0, 1}, 2}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{0, 1}, 2}, {{1, 1}, 0}}));
+    BOOST_CHECK(!edge_exists(&disparity_graph, {{{1, 1}, 0}, {{0, 1}, 2}}));
 }
 
 BOOST_AUTO_TEST_CASE(check_initial_edges_penalties)
@@ -262,34 +262,34 @@ BOOST_AUTO_TEST_CASE(check_initial_edges_penalties)
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
+        edge_penalty(&disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
         0.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{0, 1}, 1}}),
+        edge_penalty(&disparity_graph, {{{0, 0}, 0}, {{0, 1}, 1}}),
         1.0,
         0.5
     );
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{1, 0}, 1}, {{2, 0}, 0}}),
+        edge_penalty(&disparity_graph, {{{1, 0}, 1}, {{2, 0}, 0}}),
         1.0,
         0.5
     );
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 2}}),
+        edge_penalty(&disparity_graph, {{{1, 0}, 0}, {{0, 0}, 2}}),
         4.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{1, 0}, 2}, {{0, 1}, 0}}),
+        edge_penalty(&disparity_graph, {{{1, 0}, 2}, {{0, 1}, 0}}),
         4.0,
         0.5
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{1, 0}, 2}, {{1, 1}, 2}}),
+        edge_penalty(&disparity_graph, {{{1, 0}, 2}, {{1, 1}, 2}}),
         0.0,
         0.5
     );
@@ -323,23 +323,23 @@ BOOST_AUTO_TEST_CASE(check_initial_nodes_penalties)
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 1.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 2}), 1.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 0}), 1.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 1}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 2}), 1.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 1.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 1}), 4.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{1, 0}, 0}), 1.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{1, 0}, 1}), 4.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{2, 0}, 0}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{2, 0}, 0}), 0.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 0}), 0.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 1}), 4.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 1}, 2}), 1.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 1}, 0}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 1}, 1}), 4.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 1}, 2}), 1.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 1}, 0}), 0.0, 0.5);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 1}, 1}), 1.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{1, 1}, 0}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{1, 1}, 1}), 1.0, 0.5);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{2, 1}, 0}), 0.0, 0.5);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{2, 1}, 0}), 0.0, 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(check_edges_penalties)
@@ -371,27 +371,27 @@ BOOST_AUTO_TEST_CASE(check_edges_penalties)
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 10};
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})
+        reparametrization_index(&disparity_graph, {{0, 0}, 0}, {1, 0})
     ] = -2;
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
+        edge_penalty(&disparity_graph, {{{0, 0}, 0}, {{1, 0}, 0}}),
         2,
         1
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}),
+        edge_penalty(&disparity_graph, {{{0, 0}, 0}, {{1, 0}, 1}}),
         12,
         1
     );
 
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 0}}),
+        edge_penalty(&disparity_graph, {{{1, 0}, 0}, {{0, 0}, 0}}),
         2,
         1
     );
     BOOST_CHECK_CLOSE(
-        edge_penalty(disparity_graph, {{{1, 0}, 0}, {{0, 0}, 1}}),
+        edge_penalty(&disparity_graph, {{{1, 0}, 0}, {{0, 0}, 1}}),
         10,
         1
     );
@@ -426,13 +426,13 @@ BOOST_AUTO_TEST_CASE(check_nodes_penalties)
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 10, 1};
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 0}, 0}, {1, 0})
+        reparametrization_index(&disparity_graph, {{0, 0}, 0}, {1, 0})
     ] = -2;
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 0}), 8, 1);
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{0, 0}, 1}), 0, 1);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 0}), 8, 1);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{0, 0}, 1}), 0, 1);
 
-    BOOST_CHECK_CLOSE(node_penalty(disparity_graph, {{1, 0}, 0}), 10, 1);
+    BOOST_CHECK_CLOSE(node_penalty(&disparity_graph, {{1, 0}, 0}), 10, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/image.cpp
+++ b/tests/image.cpp
@@ -45,53 +45,53 @@ BOOST_AUTO_TEST_CASE(create_image)
 BOOST_AUTO_TEST_CASE(check_image_valid)
 {
     struct Image image{2, 1, 1, {0, 1}};
-    BOOST_CHECK(image_valid(image));
+    BOOST_CHECK(image_valid(&image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_value)
 {
     struct Image image{2, 1, 1, {0, 2}};
-    BOOST_CHECK(!image_valid(image));
+    BOOST_CHECK(!image_valid(&image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_max_value)
 {
     struct Image image{2, 1, 0, {0, 0}};
-    BOOST_CHECK(!image_valid(image));
+    BOOST_CHECK(!image_valid(&image));
 }
 
 BOOST_AUTO_TEST_CASE(image_invalid_size)
 {
     struct Image image{0, 0, 1, {}};
-    BOOST_CHECK(!image_valid(image));
+    BOOST_CHECK(!image_valid(&image));
 }
 
 BOOST_AUTO_TEST_CASE(check_pixel_index)
 {
     struct Image image{3, 2, 5, {5, 4, 3, 2, 1, 0}};
-    BOOST_CHECK(image_valid(image));
+    BOOST_CHECK(image_valid(&image));
     BOOST_CHECK_EQUAL(image.width, 3);
     BOOST_CHECK_EQUAL(image.height, 2);
-    BOOST_CHECK_EQUAL(pixel_index(image, {0, 0}), 0);
-    BOOST_CHECK_EQUAL(pixel_index(image, {1, 0}), 1);
-    BOOST_CHECK_EQUAL(pixel_index(image, {2, 0}), 2);
-    BOOST_CHECK_EQUAL(pixel_index(image, {0, 1}), 3);
-    BOOST_CHECK_EQUAL(pixel_index(image, {1, 1}), 4);
-    BOOST_CHECK_EQUAL(pixel_index(image, {2, 1}), 5);
+    BOOST_CHECK_EQUAL(pixel_index(&image, {0, 0}), 0);
+    BOOST_CHECK_EQUAL(pixel_index(&image, {1, 0}), 1);
+    BOOST_CHECK_EQUAL(pixel_index(&image, {2, 0}), 2);
+    BOOST_CHECK_EQUAL(pixel_index(&image, {0, 1}), 3);
+    BOOST_CHECK_EQUAL(pixel_index(&image, {1, 1}), 4);
+    BOOST_CHECK_EQUAL(pixel_index(&image, {2, 1}), 5);
 }
 
 BOOST_AUTO_TEST_CASE(check_pixel_value)
 {
     struct Image image{3, 2, 5, {5, 4, 3, 2, 1, 0}};
-    BOOST_CHECK(image_valid(image));
+    BOOST_CHECK(image_valid(&image));
     BOOST_CHECK_EQUAL(image.width, 3);
     BOOST_CHECK_EQUAL(image.height, 2);
-    BOOST_CHECK_EQUAL(pixel_value(image, {0, 0}), 5);
-    BOOST_CHECK_EQUAL(pixel_value(image, {1, 0}), 4);
-    BOOST_CHECK_EQUAL(pixel_value(image, {2, 0}), 3);
-    BOOST_CHECK_EQUAL(pixel_value(image, {0, 1}), 2);
-    BOOST_CHECK_EQUAL(pixel_value(image, {1, 1}), 1);
-    BOOST_CHECK_EQUAL(pixel_value(image, {2, 1}), 0);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {0, 0}), 5);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {1, 0}), 4);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {2, 0}), 3);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {0, 1}), 2);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {1, 1}), 1);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {2, 1}), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/labeling_finder.cpp
+++ b/tests/labeling_finder.cpp
@@ -60,9 +60,9 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 2, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
     auto pixel_penalties = fetch_pixel_available_penalties(
-        disparity_graph,
+        &disparity_graph,
         {0, 0},
         0
     );
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     BOOST_CHECK_CLOSE(pixel_penalties[0], 0, 1);
 
     auto edge_penalties = fetch_edge_available_penalties(
-        disparity_graph,
+        &disparity_graph,
         {{{0, 0}, 0}, {{0, 1}, 0}},
         0
     );
@@ -78,21 +78,21 @@ BOOST_AUTO_TEST_CASE(check_black_images)
     BOOST_CHECK_CLOSE(edge_penalties[0], 0, 1);
     BOOST_CHECK_CLOSE(edge_penalties[1], 1, 1);
 
-    auto available_penalties = fetch_available_penalties(lowest_penalties);
+    auto available_penalties = fetch_available_penalties(&lowest_penalties);
     BOOST_CHECK_EQUAL(available_penalties.size(), 2);
     BOOST_CHECK_CLOSE(available_penalties[0], 0, 1);
     BOOST_CHECK_CLOSE(available_penalties[1], 1, 1);
 
     FLOAT threshold = calculate_minimal_consistent_threshold(
-        lowest_penalties,
-        disparity_graph,
+        &lowest_penalties,
+        &disparity_graph,
         available_penalties
     );
     BOOST_CHECK_CLOSE(threshold, 0, 1);
 
     struct ConstraintGraph constraint_graph{
-        disparity_graph,
-        lowest_penalties,
+        &disparity_graph,
+        &lowest_penalties,
         threshold
     };
     BOOST_CHECK(solve_csp(&constraint_graph));
@@ -115,10 +115,10 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
 
     auto pixel_penalties = fetch_pixel_available_penalties(
-        disparity_graph,
+        &disparity_graph,
         {1, 0},
         0
     );
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     BOOST_CHECK_CLOSE(pixel_penalties[1], 129 * 129, 1);
 
     auto edge_penalties = fetch_edge_available_penalties(
-        disparity_graph,
+        &disparity_graph,
         {{{0, 0}, 0}, {{0, 1}, 0}},
         0
     );
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     BOOST_CHECK_CLOSE(edge_penalties[1], 1, 1);
     BOOST_CHECK_CLOSE(edge_penalties[2], 4, 1);
 
-    auto available_penalties = fetch_available_penalties(lowest_penalties);
+    auto available_penalties = fetch_available_penalties(&lowest_penalties);
     BOOST_CHECK_EQUAL(available_penalties.size(), 6);
     BOOST_CHECK_CLOSE(available_penalties[0], 0, 1);
     BOOST_CHECK_CLOSE(available_penalties[1], 1, 1);
@@ -146,15 +146,15 @@ BOOST_AUTO_TEST_CASE(check_equal_images)
     BOOST_CHECK_CLOSE(available_penalties[5], 256 * 256, 1);
 
     FLOAT threshold = calculate_minimal_consistent_threshold(
-        lowest_penalties,
-        disparity_graph,
+        &lowest_penalties,
+        &disparity_graph,
         available_penalties
     );
     BOOST_CHECK_CLOSE(threshold, 0, 1);
 
     struct ConstraintGraph constraint_graph{
-        disparity_graph,
-        lowest_penalties,
+        &disparity_graph,
+        &lowest_penalties,
         threshold
     };
     BOOST_CHECK(solve_csp(&constraint_graph));
@@ -188,10 +188,10 @@ BOOST_AUTO_TEST_CASE(basic_check)
     struct Image right_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
 
     auto pixel_penalties = fetch_pixel_available_penalties(
-        disparity_graph,
+        &disparity_graph,
         {0, 0},
         0
     );
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(basic_check)
     BOOST_CHECK_CLOSE(pixel_penalties[2], 36, 1);
 
     auto edge_penalties = fetch_edge_available_penalties(
-        disparity_graph,
+        &disparity_graph,
         {{{0, 0}, 0}, {{0, 1}, 0}},
         0
     );
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(basic_check)
     BOOST_CHECK_CLOSE(edge_penalties[1], 1, 1);
     BOOST_CHECK_CLOSE(edge_penalties[2], 4, 1);
 
-    auto available_penalties = fetch_available_penalties(lowest_penalties);
+    auto available_penalties = fetch_available_penalties(&lowest_penalties);
     BOOST_CHECK_EQUAL(available_penalties.size(), 6);
     BOOST_CHECK_CLOSE(available_penalties[0], 0, 1);
     BOOST_CHECK_CLOSE(available_penalties[1], 1, 1);
@@ -220,15 +220,15 @@ BOOST_AUTO_TEST_CASE(basic_check)
     BOOST_CHECK_CLOSE(available_penalties[5], 36, 1);
 
     FLOAT threshold = calculate_minimal_consistent_threshold(
-        lowest_penalties,
-        disparity_graph,
+        &lowest_penalties,
+        &disparity_graph,
         available_penalties
     );
     BOOST_CHECK_CLOSE(threshold, 5, 1);
 
     struct ConstraintGraph constraint_graph{
-        disparity_graph,
-        lowest_penalties,
+        &disparity_graph,
+        &lowest_penalties,
         threshold
     };
     BOOST_CHECK(solve_csp(&constraint_graph));

--- a/tests/lowest_penalties.cpp
+++ b/tests/lowest_penalties.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(check_neighborhoods_indexing)
     struct Image image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{image, image, 3, 1, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
     BOOST_CHECK_EQUAL(
         neighborhood_index_fast(lowest_penalties.graph, {0, 0}, 0),
         0
@@ -316,15 +316,15 @@ BOOST_AUTO_TEST_CASE(check_lowest_pixel_penalty)
     struct Image right_image{*pgm_io.get_image()};
 
     struct DisparityGraph disparity_graph{left_image, right_image, 2, 10, 1};
-    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
 
-    BOOST_CHECK_CLOSE(lowest_pixel_penalty(lowest_penalties, {0, 0}), 10, 1);
-    BOOST_CHECK_CLOSE(lowest_pixel_penalty(lowest_penalties, {1, 0}), 10, 1);
-    BOOST_CHECK_CLOSE(lowest_pixel_penalty(lowest_penalties, {2, 0}), 40, 1);
+    BOOST_CHECK_CLOSE(lowest_pixel_penalty(&lowest_penalties, {0, 0}), 10, 1);
+    BOOST_CHECK_CLOSE(lowest_pixel_penalty(&lowest_penalties, {1, 0}), 10, 1);
+    BOOST_CHECK_CLOSE(lowest_pixel_penalty(&lowest_penalties, {2, 0}), 40, 1);
 
-    BOOST_CHECK_CLOSE(lowest_pixel_penalty(lowest_penalties, {0, 1}), 0, 1);
-    BOOST_CHECK_CLOSE(lowest_pixel_penalty(lowest_penalties, {1, 1}), 0, 1);
-    BOOST_CHECK_CLOSE(lowest_pixel_penalty(lowest_penalties, {2, 1}), 90, 1);
+    BOOST_CHECK_CLOSE(lowest_pixel_penalty(&lowest_penalties, {0, 1}), 0, 1);
+    BOOST_CHECK_CLOSE(lowest_pixel_penalty(&lowest_penalties, {1, 1}), 0, 1);
+    BOOST_CHECK_CLOSE(lowest_pixel_penalty(&lowest_penalties, {2, 1}), 90, 1);
 }
 
 BOOST_AUTO_TEST_CASE(check_lowest_vertical_neighborhood_penalty)
@@ -356,29 +356,29 @@ BOOST_AUTO_TEST_CASE(check_lowest_vertical_neighborhood_penalty)
     struct DisparityGraph disparity_graph{left_image, right_image, 3, 1, 1};
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 0}, 0}, {0, 1})
+        reparametrization_index(&disparity_graph, {{0, 0}, 0}, {0, 1})
     ] = -5;
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 0}, 1}, {0, 1})
+        reparametrization_index(&disparity_graph, {{0, 0}, 1}, {0, 1})
     ] = -5;
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 0}, 2}, {0, 1})
+        reparametrization_index(&disparity_graph, {{0, 0}, 2}, {0, 1})
     ] = 0;
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 1}, 0}, {0, 0})
+        reparametrization_index(&disparity_graph, {{0, 1}, 0}, {0, 0})
     ] = 0;
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 1}, 1}, {0, 0})
+        reparametrization_index(&disparity_graph, {{0, 1}, 1}, {0, 0})
     ] = -5;
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{0, 1}, 2}, {0, 0})
+        reparametrization_index(&disparity_graph, {{0, 1}, 2}, {0, 0})
     ] = -5;
 
-    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
 
     BOOST_CHECK_CLOSE(
-        lowest_neighborhood_penalty_fast(lowest_penalties, {0, 0}, {0, 1}),
+        lowest_neighborhood_penalty_fast(&lowest_penalties, {0, 0}, {0, 1}),
         4,
         1
     );
@@ -413,58 +413,58 @@ BOOST_AUTO_TEST_CASE(check_lowest_neighborhood_penalty)
     struct DisparityGraph disparity_graph{left_image, right_image, 2, 1, 10};
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{1, 0}, 0}, {1, 1})
+        reparametrization_index(&disparity_graph, {{1, 0}, 0}, {1, 1})
     ] = 0.5;
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{1, 0}, 0}, {2, 0})
+        reparametrization_index(&disparity_graph, {{1, 0}, 0}, {2, 0})
     ] = -2;
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{2, 0}, 1}, {1, 0})
+        reparametrization_index(&disparity_graph, {{2, 0}, 1}, {1, 0})
     ] = -2;
 
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{2, 0}, 0}, {2, 1})
+        reparametrization_index(&disparity_graph, {{2, 0}, 0}, {2, 1})
     ] = -1;
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{2, 1}, 0}, {2, 0})
+        reparametrization_index(&disparity_graph, {{2, 1}, 0}, {2, 0})
     ] = -1;
 
-    struct LowestPenalties lowest_penalties{disparity_graph};
+    struct LowestPenalties lowest_penalties{&disparity_graph};
 
     /**
      * This should not affect the final weights,
      * because it's modified after minimal penalties calculation.
      */
     disparity_graph.reparametrization[
-        reparametrization_index(disparity_graph, {{1, 1}, 0}, {1, 0})
+        reparametrization_index(&disparity_graph, {{1, 1}, 0}, {1, 0})
     ] = 0.5;
 
     BOOST_CHECK_CLOSE(
-        lowest_neighborhood_penalty_fast(lowest_penalties, {0, 0}, {1, 0}),
+        lowest_neighborhood_penalty_fast(&lowest_penalties, {0, 0}, {1, 0}),
         0,
         1
     );
     BOOST_CHECK_CLOSE(
-        lowest_neighborhood_penalty_fast(lowest_penalties, {0, 0}, {0, 1}),
+        lowest_neighborhood_penalty_fast(&lowest_penalties, {0, 0}, {0, 1}),
         0,
         1
     );
 
     BOOST_CHECK_CLOSE(
-        lowest_neighborhood_penalty_fast(lowest_penalties, {1, 0}, {1, 1}),
+        lowest_neighborhood_penalty_fast(&lowest_penalties, {1, 0}, {1, 1}),
         -0.5,
         1
     );
 
     BOOST_CHECK_CLOSE(
-        lowest_neighborhood_penalty_fast(lowest_penalties, {1, 0}, {2, 0}),
+        lowest_neighborhood_penalty_fast(&lowest_penalties, {1, 0}, {2, 0}),
         2,
         1
     );
 
     BOOST_CHECK_CLOSE(
-        lowest_neighborhood_penalty_fast(lowest_penalties, {2, 0}, {2, 1}),
+        lowest_neighborhood_penalty_fast(&lowest_penalties, {2, 0}, {2, 1}),
         2,
         1
     );

--- a/tests/pgm_io.cpp
+++ b/tests/pgm_io.cpp
@@ -61,12 +61,12 @@ BOOST_AUTO_TEST_CASE(read_image)
     BOOST_CHECK_EQUAL(pgm_io.get_image()->max_value, 10);
 
     struct Image image{*pgm_io.get_image()};
-    BOOST_CHECK_EQUAL(pixel_value(image, {0, 0}), 0);
-    BOOST_CHECK_EQUAL(pixel_value(image, {1, 0}), 1);
-    BOOST_CHECK_EQUAL(pixel_value(image, {2, 0}), 2);
-    BOOST_CHECK_EQUAL(pixel_value(image, {0, 1}), 3);
-    BOOST_CHECK_EQUAL(pixel_value(image, {1, 1}), 4);
-    BOOST_CHECK_EQUAL(pixel_value(image, {2, 1}), 5);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {0, 0}), 0);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {1, 0}), 1);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {2, 0}), 2);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {0, 1}), 3);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {1, 1}), 4);
+    BOOST_CHECK_EQUAL(pixel_value(&image, {2, 1}), 5);
 }
 
 BOOST_AUTO_TEST_CASE(read_blank_file)


### PR DESCRIPTION
This was a really boring and long task. I've created an OpenCL kernel for task #99, and got a lot of errors. I've hardly recalled how to read error messages (I used a binary search of errors before this), and then the work came faster.
The issues are:

- OpenCL 1.2 doesn't understand references. I cannot use OpenCL 2, because it seems not to be supported by my nVidia GPU;
- OpenCL 1.2 needs a `struct` keyword before structure instantiation;
- OpenCL 1.2 doesn't have `bool`, and, consequently, `true` and `false` &mdash; needed to create macros for them;
- OpenCL 1.2 doesn't understand structure initialization with curly braces nor parentheses &mdash; needed to assign each field separately after the instantiation.
- All tests and functions calls should have been changed (and they have been).

Treat as warnings

- `hicpp-vararg` to allow call of C-style vararg functions;
- `cppcoreguidelines-pro-type-member-init` to avoid mandatory `struct initialization;
- `hicpp-member-init` to avoid mandatory `struct initialization;
- `modernize-use-nullptr` to allow usage of `NULL` instead of `nullptr`.