### PR TITLE
Close #99: Add ability to use OpenCL for CSP solution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - os: linux
       dist: bionic
       env:
-        - MATRIX_EVAL="CC=clang-7.0 && CXX=clang++-7.0"
+        - MATRIX_EVAL="CC=clang-7.0.0 && CXX=clang++-7.0.0"
 
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer make all
+        clang-static-analyzer make . -j 1
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ before_script:
         -v -v -v"
 
 script:
+    - echo "$CC $CXX $(which $CC) $(which $CXX) $(which clang) $(which clang++)"
     - mkdir build
     - cd build
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,7 @@ before_install:
 
 before_script:
     - sudo apt-get update
-    - sudo apt-get install -y
-        libboost-test-dev
-        libboost-program-options-dev
+    - sudo apt-get install -y libboost-dev
     - shopt -s expand_aliases
     - alias clang-static-analyzer="scan-build
         --use-cc=`which $CC`

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: cpp
 matrix:
   include:
     - os: linux
-      addons:
-        apt:
-          packages:
-            - llvm-7.0
-            - clang-7.0
       env:
         - MATRIX_EVAL="CC=clang-7.0 && CXX=clang++-7.0"
 
@@ -16,7 +11,6 @@ matrix:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - llvm-6.0
             - clang-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: cpp
 matrix:
   include:
     - os: linux
+      dist: bionic
       env:
         - MATRIX_EVAL="CC=clang-7.0 && CXX=clang++-7.0"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -18,6 +20,7 @@ matrix:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -28,6 +31,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -38,6 +42,7 @@ matrix:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -48,6 +53,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ before_script:
     - sudo apt-get install -y
         libboost-test-dev
         libboost-program-options-dev
-        libboost-dev
     - shopt -s expand_aliases
     - alias clang-static-analyzer="scan-build
         --use-cc=`which $CC`

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 matrix:
   include:
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -15,6 +16,7 @@ matrix:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -25,6 +27,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -35,6 +38,7 @@ matrix:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -45,6 +49,7 @@ matrix:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -55,6 +60,7 @@ matrix:
         - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
 
     - os: linux
+      dist: bionic
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        VERBOSE=1 clang-static-analyzer cmake --build .
+        VERBOSE=1 clang-static-analyzer make . -j 1
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: cpp
 matrix:
   include:
     - os: linux
-      env:
-        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
-
-    - os: linux
       addons:
         apt:
           sources:
@@ -99,7 +95,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer make
+        clang-static-analyzer make all
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,11 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: bionic
-      env:
-        - MATRIX_EVAL="CC=clang-7.0.0 && CXX=clang++-7.0.0"
-
-    - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - llvm-6.0
             - clang-6.0
@@ -20,7 +15,6 @@ matrix:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
@@ -31,7 +25,6 @@ matrix:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
@@ -42,7 +35,6 @@ matrix:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
@@ -53,7 +45,16 @@ matrix:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
     - os: linux
-      dist: bionic
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+
+    - os: linux
       addons:
         apt:
           sources:
@@ -85,7 +86,6 @@ before_script:
         -v -v -v"
 
 script:
-    - echo "$CC $CXX $(which $CC) $(which $CXX) $(which clang) $(which clang++)"
     - mkdir build
     - cd build
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,10 @@ before_install:
 
 before_script:
     - sudo apt-get update
-    - sudo apt-get install -y libboost-dev
+    - sudo apt-get install -y
+        libboost-test-dev
+        libboost-program-options-dev
+        libboost-dev
     - shopt -s expand_aliases
     - alias clang-static-analyzer="scan-build
         --use-cc=`which $CC`

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
     - os: linux
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
+        - MATRIX_EVAL="CC=clang-7 && CXX=clang++-7"
 
     - os: linux
       addons:
@@ -99,7 +99,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        VERBOSE=1 clang-static-analyzer make . -j 1
+        clang-static-analyzer make
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ matrix:
   include:
     - os: linux
       dist: bionic
+      env:
+        - MATRIX_EVAL="CC=clang-7.0 && CXX=clang++-7.0"
+
+    - os: linux
+      dist: bionic
       addons:
         apt:
           sources:
@@ -47,17 +52,6 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-
-    - os: linux
-      dist: bionic
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-4.9
-          packages:
-            - clang-4.9
-      env:
-        - MATRIX_EVAL="CC=clang-4.9 && CXX=clang++-4.9"
 
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,9 +99,8 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        VERBOSE=1 clang-static-analyzer cmake --build . 2>err.log
+        VERBOSE=1 clang-static-analyzer cmake --build .
       fi
-    - cat err.log
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..
     - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer make -j 1
+        clang-static-analyzer make .
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,9 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer cmake --build .
+        VERBOSE=1 clang-static-analyzer cmake --build . 2>err.log
       fi
+    - cat err.log
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..
     - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-6.0
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+            - ubuntu-toolchain-r-test
           packages:
-            - llvm-6.0
             - clang-6.0
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
@@ -28,7 +26,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
           packages:
             - clang-5.0
       env:
@@ -48,7 +46,7 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-4.0
+            - ubuntu-toolchain-r-test
           packages:
             - clang-4.0
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,11 @@ matrix:
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-trusty-4.9
           packages:
-            - clang-4.0
+            - clang-4.9
       env:
-        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+        - MATRIX_EVAL="CC=clang-4.9 && CXX=clang++-4.9"
 
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \
-        clang-static-analyzer make . -j 1
+        clang-static-analyzer make -j 1
       fi
     - rm -rf *
     - cmake -DCMAKE_CXX_FLAGS="-pedantic -Wall -Wextra -Werror" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,15 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: bionic
+      addons:
+        apt:
+          packages:
+            - llvm-7.0
+            - clang-7.0
       env:
         - MATRIX_EVAL="CC=clang-7.0 && CXX=clang++-7.0"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
@@ -21,7 +24,6 @@ matrix:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
@@ -32,7 +34,6 @@ matrix:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
@@ -43,7 +44,6 @@ matrix:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:
@@ -54,7 +54,6 @@ matrix:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
     - os: linux
-      dist: bionic
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ script:
       then
         BUILD_DIR="${TRAVIS_BUILD_DIR}" && \
         clang-static-analyzer cmake \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=${BUILD_DIR};" \
             -DCMAKE_BUILD_TYPE=Debug \
             .. && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: cpp
 matrix:
   include:
     - os: linux
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+
+    - os: linux
       addons:
         apt:
           sources:

--- a/include/compile_cl.hpp
+++ b/include/compile_cl.hpp
@@ -1,0 +1,54 @@
+#ifndef COMPILE_CL_HPP
+#define COMPILE_CL_HPP
+
+#include <string>
+#include <vector>
+
+#define BOOST_COMPUTE_DEBUG_KERNEL_COMPILATION
+
+#include <boost/compute.hpp>
+
+namespace gpu
+{
+
+using std::string;
+using std::vector;
+
+using boost::compute::program;
+using boost::compute::context;
+
+/**
+ * \brief Build an OpenCL program from a single file.
+ *
+ * The program is built using OpenCL 1.2.
+ * This is done for the compatibility with nVidia devices.
+ *
+ * Headers are included from the `./include` folder of the project.
+ * This is done to use one code for both CPU and GPU:
+ * headers are located at the `./include` directory.
+ */
+program create_program(const string& filename, const context& context);
+/**
+ * \brief Build an OpenCL program from multiple files.
+ * Needed for the case when the code is split into separate files.
+ *
+ * The program is built using OpenCL 1.2.
+ * This is done for the compatibility with nVidia devices.
+ *
+ * Headers are included from the `./include` folder of the project.
+ * This is done to use one code for both CPU and GPU:
+ * headers are located at the `./include` directory.
+ */
+program create_program(const vector<string>& filenames, const context& context);
+/**
+ * \brief Concatenate contents of multiple files.
+ *
+ * As long as I don't know
+ * how to build an OpenCL program directly from multiple sources,
+ * I need to read several files and concatenate them into a string.
+ */
+string concatenate_files(const vector<string>& filenames);
+
+}
+
+#endif

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -300,7 +300,7 @@ struct ConstraintGraph
      * \f$i\f$ is an index of used neighbor
      * and \f$d\f$ is a Node::disparity.
      */
-    BOOL_ARRAY nodes_availability;
+    __global BOOL_ARRAY nodes_availability;
     /**
      * \brief Threshold to compare penalty of an edge with the minimal one
      * against.

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -29,6 +29,7 @@
 #include <lowest_penalties.hpp>
 #include <types.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 /**
  * \brief Utilities to solve CSP.
  */
@@ -43,6 +44,7 @@ using sp::types::Edge;
 using sp::types::FLOAT;
 using sp::types::Node;
 using sp::types::ULONG;
+#endif
 
 /**
  * \brief Structure to represent a graph with constraints
@@ -319,11 +321,13 @@ struct ConstraintGraph
      * it's good to have precalculated
      * sp::graph::lowest_penalties::LowestPenalties instance.
      */
+    #ifndef __OPENCL_C_VERSION__
     ConstraintGraph(
         const struct DisparityGraph* disparity_graph,
         const struct LowestPenalties* lowest_penalties,
         FLOAT threshold
     );
+    #endif
 };
 /**
  * \brief Mark specific Node as available (`true`).
@@ -434,6 +438,8 @@ BOOL solve_csp(struct ConstraintGraph* graph);
  */
 BOOL check_nodes_left(const struct ConstraintGraph* graph);
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/include/constraint_graph.hpp
+++ b/include/constraint_graph.hpp
@@ -43,6 +43,7 @@ using sp::types::BOOL_ARRAY;
 using sp::types::Edge;
 using sp::types::FLOAT;
 using sp::types::Node;
+using sp::types::Pixel;
 using sp::types::ULONG;
 #endif
 
@@ -398,6 +399,19 @@ BOOL is_edge_available(
 BOOL should_remove_node(
     const struct ConstraintGraph* graph,
     struct Node node
+);
+/**
+ * \brief Check all nodes of the Pixel and remove the redundant ones.
+ *
+ * @return
+ *  Boolean flag.
+ *  `true` if availability of at least one node was changed.
+ *  `false` if a solution was found (at least an empty one)
+ *  and nothing was changed during iteration.
+ */
+BOOL csp_process_pixel(
+    struct ConstraintGraph* graph,
+    struct Pixel pixel
 );
 /**
  * \brief Perform one iteration of sp::graph::constraint::solve_csp.

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -53,6 +53,8 @@ using sp::types::ULONG;
  * - top
  */
 const ULONG NEIGHBORS_COUNT = 4;
+#else
+#define NEIGHBORS_COUNT (4)
 #endif
 
 /**

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -379,7 +379,7 @@ struct DisparityGraph
      * \f$i\f$ is an index of used neighbor
      * and \f$d\f$ is a Node::disparity.
      */
-    FLOAT_ARRAY reparametrization;
+    __global FLOAT_ARRAY reparametrization;
     /**
      * \brief Weight of difference in colors
      * between pixel and its neighbor.

--- a/include/disparity_graph.hpp
+++ b/include/disparity_graph.hpp
@@ -29,6 +29,7 @@
 
 #define MAX(x, y) ((x) >= (y)? (x) : (y))
 
+#ifndef __OPENCL_C_VERSION__
 /**
  * \brief Graph representation of disparity map support.
  */
@@ -52,6 +53,7 @@ using sp::types::ULONG;
  * - top
  */
 const ULONG NEIGHBORS_COUNT = 4;
+#endif
 
 /**
  * \brief Structure to represent a graph of MRF
@@ -404,6 +406,7 @@ struct DisparityGraph
      * and initialize its
      * sp::graph::disparity::DisparityGraph::reparametrization.
      */
+    #ifndef __OPENCL_C_VERSION__
     DisparityGraph(
         struct Image left,
         struct Image right,
@@ -411,6 +414,7 @@ struct DisparityGraph
         FLOAT cleanness,
         FLOAT smoothness
     );
+    #endif
 };
 
 /**
@@ -438,6 +442,8 @@ FLOAT edge_penalty(const struct DisparityGraph* graph, struct Edge edge);
  */
 FLOAT node_penalty(const struct DisparityGraph* graph, struct Node node);
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/include/gpu_csp.hpp
+++ b/include/gpu_csp.hpp
@@ -1,0 +1,75 @@
+#ifndef GPU_CSP_HPP
+#define GPU_CSP_HPP
+
+#include <compile_cl.hpp>
+#include <constraint_graph.hpp>
+
+namespace gpu
+{
+
+namespace compute = boost::compute;
+
+using boost::compute::command_queue;
+using boost::compute::program;
+using sp::graph::constraint::ConstraintGraph;
+using sp::types::BOOL;
+using sp::types::FLOAT;
+using sp::types::ULONG;
+
+/**
+ * Source files for CSP solution.
+ */
+const vector<string> SOURCE_FILES = {
+    "lib/constraint_graph.cpp",
+    "lib/lowest_penalties.cpp",
+    "lib/labeling_finder.cpp",
+    "lib/disparity_graph.cpp",
+    "lib/image.cpp",
+    "lib/indexing_checks.cpp",
+    "lib/indexing.cpp",
+    "lib/solve_csp.cl",
+};
+
+/**
+ * \brief Problem representation to be placed into GPU memory.
+ * Flattened version of sp::graph::constraint::ConstraintGraph.
+ */
+struct Problem
+{
+    program program;
+    command_queue queue;
+    compute::vector<cl_ulong> left_image;
+    compute::vector<cl_ulong> changed;
+    compute::vector<cl_ulong> right_image;
+    compute::vector<cl_float> min_penalties_pixels;
+    compute::vector<cl_float> min_penalties_edges;
+    compute::vector<cl_float> reparametrization;
+};
+
+/**
+ * \brief Create command queue and program for solving CSP,
+ * and add them to the Problem.
+ */
+void build_csp_program(struct Problem* problem);
+/**
+ * Initialize fields of the Problem
+ * with values from the sp::graph::constraint::ConstraintGraph.
+ */
+void prepare_problem(struct ConstraintGraph* graph, struct Problem* problem);
+
+/**
+ * \brief Remove all nodes that have no any edges at least to one neighbor
+ * until there is nothing to remove
+ * (anything is removed or all nodes have neighbors),
+ * and save the nodes availability data
+ * (sp::graph::constraint::ConstraintGraph::nodes_availability)
+ * into the input sp::graph::constraint::ConstraintGraph.
+ */
+BOOL csp_solution_cl(
+    struct ConstraintGraph* graph,
+    struct Problem* problem
+);
+
+}
+
+#endif

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -78,7 +78,7 @@ struct Image
      *  \end{bmatrix}
      * \f]
      */
-    ULONG_ARRAY data;
+    __global ULONG_ARRAY data;
 };
 
 /**

--- a/include/image.hpp
+++ b/include/image.hpp
@@ -26,6 +26,7 @@
 
 #include <types.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 /**
  * \brief Image processing utilities.
  */
@@ -35,6 +36,7 @@ namespace sp::image
 using sp::types::BOOL;
 using sp::types::ULONG;
 using sp::types::ULONG_ARRAY;
+#endif
 
 /**
  * \brief Structure to represent image on both CPU and GPU.
@@ -88,6 +90,8 @@ struct Image
  */
 BOOL image_valid(const struct Image* image);
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/include/indexing.hpp
+++ b/include/indexing.hpp
@@ -28,6 +28,7 @@
 #include <image.hpp>
 #include <types.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 /**
  * \brief Functions for getting access to arrays
  * by abstract indices like sp::types::Pixels, sp::types::Nodes, etc.
@@ -42,6 +43,7 @@ using sp::types::FLOAT;
 using sp::types::Node;
 using sp::types::Pixel;
 using sp::types::ULONG;
+#endif
 
 /**
  * \brief Get position of the pixel in data array of the image.
@@ -223,6 +225,8 @@ struct Pixel neighbor_by_index(
     ULONG neighbor_index
 );
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/include/indexing_checks.hpp
+++ b/include/indexing_checks.hpp
@@ -26,6 +26,7 @@
 
 #include <disparity_graph.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 /**
  * \brief Checks for the availability of indices.
  */
@@ -38,6 +39,7 @@ using sp::types::FLOAT;
 using sp::types::Node;
 using sp::types::Pixel;
 using sp::types::ULONG;
+#endif
 
 /**
  * \brief Check wheter provided Pixel instances
@@ -105,6 +107,8 @@ bool edge_exists(
     struct Edge edge
 );
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -138,7 +138,20 @@ struct ConstraintGraph* choose_best_node(
     struct Pixel pixel
 );
 /**
- * \brief Find a labeling, consistent with the minimal available threshold.
+ * \brief Find a labeling, consistent with the minimal available threshold,
+ * using OpenCL.
+ *
+ * Use sp::labeling::finder::calculate_minimal_consistent_threshold
+ * to find the threshold.
+ *
+ * The function performs the same actions as find_labeling.
+ */
+struct ConstraintGraph* find_labeling_cl(
+    struct ConstraintGraph* graph
+);
+/**
+ * \brief Find a labeling, consistent with the minimal available threshold,
+ * using CPU. Use OpenMP if available.
  *
  * Use sp::labeling::finder::calculate_minimal_consistent_threshold
  * to find the threshold.

--- a/include/labeling_finder.hpp
+++ b/include/labeling_finder.hpp
@@ -30,6 +30,7 @@
 #include <lowest_penalties.hpp>
 #include <types.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 /**
  * \brief Functions to find a consistent labeling.
  */
@@ -44,6 +45,7 @@ using sp::types::Edge;
 using sp::types::FLOAT;
 using sp::types::FLOAT_ARRAY;
 using sp::types::Pixel;
+#endif
 
 /**
  * \brief Construct an array of available differences
@@ -165,6 +167,8 @@ struct Image build_disparity_map(
     const struct ConstraintGraph* constraint_graph
 );
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/include/lowest_penalties.hpp
+++ b/include/lowest_penalties.hpp
@@ -33,6 +33,7 @@
 #include <indexing.hpp>
 #include <types.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 /**
  * \brief Utilities to find locally best nodes and edges.
  */
@@ -46,6 +47,7 @@ using sp::types::FLOAT;
 using sp::types::FLOAT_ARRAY;
 using sp::types::Pixel;
 using sp::types::ULONG;
+#endif
 
 /**
  * \brief Graph containing lowest penalties for
@@ -116,7 +118,9 @@ struct LowestPenalties
      * after sp::graph::lowest_penalties::LowestPenalties construction,
      * the sp::graph::lowest_penalties::LowestPenalties instance will not be changed.
      */
+    #ifndef __OPENCL_C_VERSION__
     explicit LowestPenalties(const struct DisparityGraph* graph);
+    #endif
 };
 /**
  * \brief Calculate minimal penalty among nodes of a pixel.
@@ -194,6 +198,8 @@ FLOAT lowest_neighborhood_penalty(
     struct Edge edge
 );
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/include/lowest_penalties.hpp
+++ b/include/lowest_penalties.hpp
@@ -89,7 +89,7 @@ struct LowestPenalties
      *  k\left( \left\langle x, y \right\rangle \right) = y + h \cdot x.
      * \f]
      */
-    FLOAT_ARRAY pixels;
+    __global FLOAT_ARRAY pixels;
     /**
      * \brief Minimal penalties of edges per neighborhood.
      *
@@ -104,7 +104,7 @@ struct LowestPenalties
      * where \f$i\f$ is an index of the neighbor,
      * and \f$\max\limits_j{\left| \mathcal{N}_j \right|}\f$ is sp::graph::disparity::NEIGHBORS_COUNT.
      */
-    FLOAT_ARRAY neighborhoods;
+    __global FLOAT_ARRAY neighborhoods;
     /**
      * \brief Calculate lowest penalties from sp::graph::disparity::DisparityGraph.
      *

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -71,6 +71,18 @@ using BOOL_ARRAY = std::vector<BOOL>;
 const BOOL TRUE = true;
 const BOOL FALSE = false;
 
+#else
+
+#define ULONG ulong
+#define ULONG_ARRAY ULONG*
+#define FLOAT float
+#define FLOAT_ARRAY FLOAT*
+#define BOOL int
+#define BOOL_ARRAY BOOL*
+
+#define TRUE 1
+#define FALSE 0
+
 #endif
 
 /**

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -27,6 +27,7 @@
 #ifndef __OPENCL_C_VERSION__
 #include <vector>
 
+#define __global
 /**
  * \brief Basic types.
  */

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -24,6 +24,7 @@
 #ifndef TYPES_HPP
 #define TYPES_HPP
 
+#ifndef __OPENCL_C_VERSION__
 #include <vector>
 
 /**
@@ -69,6 +70,8 @@ using BOOL_ARRAY = std::vector<BOOL>;
 
 const BOOL TRUE = true;
 const BOOL FALSE = false;
+
+#endif
 
 /**
  * Structure that contains position of a pixel.
@@ -120,6 +123,8 @@ struct Edge
     struct Node neighbor;
 };
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif
 
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,8 +37,10 @@ add_library(constraint_graph constraint_graph.cpp)
 add_library(labeling_finder labeling_finder.cpp)
 add_library(indexing indexing.cpp)
 add_library(indexing_checks indexing_checks.cpp)
+if (OpenCL_FOUND)
 add_library(compile_cl compile_cl.cpp)
 add_library(gpu_csp gpu_csp.cpp)
+endif (OpenCL_FOUND)
 
 target_include_directories(
     indexing PUBLIC
@@ -72,6 +74,7 @@ target_include_directories(
     labeling_finder PUBLIC
     ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
 )
+if (OpenCL_FOUND)
 target_include_directories(
     compile_cl PUBLIC
     ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
@@ -80,6 +83,7 @@ target_include_directories(
     gpu_csp PUBLIC
     ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
 )
+endif (OpenCL_FOUND)
 
 target_link_libraries(
     pgm_io
@@ -110,14 +114,21 @@ if (OpenMP_CXX_FOUND)
         OpenMP::OpenMP_CXX
     )
 endif (OpenMP_CXX_FOUND)
+
 target_link_libraries(
     labeling_finder
     constraint_graph
     lowest_penalties
     disparity_graph
     image
-    gpu_csp
 )
+
+if (OpenCL_FOUND)
+    target_link_libraries(
+        labeling_finder
+        gpu_csp
+    )
+endif (OpenCL_FOUND)
 
 if (OpenCL_FOUND)
     target_link_libraries(

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,6 +25,9 @@ find_package(Boost 1.54 REQUIRED COMPONENTS program_options)
 if (WITH_OPENMP)
     find_package(OpenMP REQUIRED)
 endif(WITH_OPENMP)
+if (WITH_OPENCL)
+    find_package(OpenCL REQUIRED)
+endif(WITH_OPENCL)
 
 add_library(image image.cpp)
 add_library(pgm_io pgm_io.cpp)
@@ -34,6 +37,8 @@ add_library(constraint_graph constraint_graph.cpp)
 add_library(labeling_finder labeling_finder.cpp)
 add_library(indexing indexing.cpp)
 add_library(indexing_checks indexing_checks.cpp)
+add_library(compile_cl compile_cl.cpp)
+add_library(gpu_csp gpu_csp.cpp)
 
 target_include_directories(
     indexing PUBLIC
@@ -65,6 +70,14 @@ target_include_directories(
 )
 target_include_directories(
     labeling_finder PUBLIC
+    ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
+)
+target_include_directories(
+    compile_cl PUBLIC
+    ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
+)
+target_include_directories(
+    gpu_csp PUBLIC
     ${STEREO_PARALLEL_MAIN_INCLUDE_DIR}
 )
 
@@ -103,7 +116,21 @@ target_link_libraries(
     lowest_penalties
     disparity_graph
     image
+    gpu_csp
 )
+
+if (OpenCL_FOUND)
+    target_link_libraries(
+        compile_cl
+        OpenCL::OpenCL
+    )
+    target_link_libraries(
+        gpu_csp
+        constraint_graph
+        compile_cl
+        OpenCL::OpenCL
+    )
+endif (OpenCL_FOUND)
 
 add_executable(stereo_parallel main.cpp)
 target_include_directories(
@@ -120,3 +147,10 @@ target_link_libraries(
     labeling_finder
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )
+
+if (OpenCL_FOUND)
+    target_link_libraries(
+        stereo_parallel
+        gpu_csp
+    )
+endif (OpenCL_FOUND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -128,6 +128,11 @@ if (OpenCL_FOUND)
         labeling_finder
         gpu_csp
     )
+    target_compile_definitions(
+        labeling_finder
+        PRIVATE
+        "USE_OPENCL"
+    )
 endif (OpenCL_FOUND)
 
 if (OpenCL_FOUND)
@@ -163,5 +168,10 @@ if (OpenCL_FOUND)
     target_link_libraries(
         stereo_parallel
         gpu_csp
+    )
+    target_compile_definitions(
+        stereo_parallel
+        PRIVATE
+        "USE_OPENCL"
     )
 endif (OpenCL_FOUND)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,6 +26,7 @@ if (WITH_OPENMP)
     find_package(OpenMP REQUIRED)
 endif(WITH_OPENMP)
 if (WITH_OPENCL)
+    find_package(Boost 1.61 REQUIRED)
     find_package(OpenCL REQUIRED)
 endif(WITH_OPENCL)
 

--- a/lib/compile_cl.cpp
+++ b/lib/compile_cl.cpp
@@ -1,0 +1,52 @@
+#include <compile_cl.hpp>
+
+#define BOOST_COMPUTE_DEBUG_KERNEL_COMPILATION
+#include <boost/compute.hpp>
+
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace gpu
+{
+
+using std::ifstream;
+using std::istreambuf_iterator;
+using std::string;
+using std::vector;
+
+using boost::compute::program;
+using boost::compute::system;
+using boost::compute::context;
+
+program create_program(const string& filename, const context& context)
+{
+    return create_program(vector<string>{filename}, context);
+}
+
+program create_program(const vector<string>& filenames, const context& context)
+{
+    program program = program::build_with_source(
+        concatenate_files(filenames),
+        context,
+        "-cl-std=CL1.2 -I ./include"
+    );
+    return program;
+}
+
+string concatenate_files(const vector<string>& filenames)
+{
+    string result = "";
+    for (unsigned i = 0; i < filenames.size(); ++i)
+    {
+        ifstream file{filenames[i]};
+        result += string{
+            istreambuf_iterator<char>{file},
+            istreambuf_iterator<char>{}
+        };
+    }
+    return result;
+}
+
+}

--- a/lib/compile_cl.cpp
+++ b/lib/compile_cl.cpp
@@ -17,7 +17,6 @@ using std::string;
 using std::vector;
 
 using boost::compute::program;
-using boost::compute::system;
 using boost::compute::context;
 
 program create_program(const string& filename, const context& context)
@@ -37,10 +36,10 @@ program create_program(const vector<string>& filenames, const context& context)
 
 string concatenate_files(const vector<string>& filenames)
 {
-    string result = "";
-    for (unsigned i = 0; i < filenames.size(); ++i)
+    string result;
+    for (const string& filename : filenames)
     {
-        ifstream file{filenames[i]};
+        ifstream file{filename};
         result += string{
             istreambuf_iterator<char>{file},
             istreambuf_iterator<char>{}

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -359,7 +359,7 @@ BOOL solve_csp(struct ConstraintGraph* graph)
     {
         changed = FALSE;
         #ifdef _OPENMP
-        #pragma omp parallel for reduction(|:changed)
+        #pragma omp parallel for reduction(||:changed)
         #endif
         for (ULONG i = 0; i < THREADS_NUMBER; ++i)
         {

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -254,6 +254,32 @@ BOOL check_nodes_left(const struct ConstraintGraph* graph)
     return FALSE;
 }
 
+BOOL csp_process_pixel(
+    struct ConstraintGraph* graph,
+    struct Pixel pixel
+)
+{
+    struct Node node;
+    node.pixel = pixel;
+
+    BOOL changed = FALSE;
+    for (
+        node.disparity = 0;
+        node.pixel.x + node.disparity
+            < graph->disparity_graph->right.width
+        && node.disparity < graph->disparity_graph->disparity_levels;
+        ++node.disparity
+    )
+    {
+        if (should_remove_node(graph, node))
+        {
+            make_node_unavailable(graph, node);
+            changed = TRUE;
+        }
+    }
+    return changed;
+}
+
 BOOL csp_solution_iteration(
     struct ConstraintGraph* graph,
     ULONG jobs,
@@ -285,6 +311,7 @@ BOOL csp_solution_iteration(
             ++node.pixel.x
         )
         {
+            csp_process_pixel(graph, node.pixel);
             pixel_available = FALSE;
             for (
                 node.disparity = 0;
@@ -294,12 +321,7 @@ BOOL csp_solution_iteration(
                 ++node.disparity
             )
             {
-                if (should_remove_node(graph, node))
-                {
-                    make_node_unavailable(graph, node);
-                    changed = TRUE;
-                }
-                else if (is_node_available(graph, node))
+                if (is_node_available(graph, node))
                 {
                     pixel_available = TRUE;
                 }

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -30,12 +30,17 @@
 #include <omp.h>
 #endif
 
+#ifndef __OPENCL_C_VERSION__
+#include <iostream>
+#endif
+
 #ifdef _OPENMP
 #define THREADS_NUMBER (omp_get_num_threads())
 #else
 #define THREADS_NUMBER (1)
 #endif
 
+#ifndef __OPENCL_C_VERSION__
 namespace sp::graph::constraint
 {
 
@@ -101,6 +106,7 @@ ConstraintGraph::ConstraintGraph(
         }
     }
 }
+#endif
 
 void make_node_available(
     struct ConstraintGraph* graph,
@@ -340,4 +346,6 @@ BOOL solve_csp(struct ConstraintGraph* graph)
     return check_nodes_left(graph);
 }
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif

--- a/lib/constraint_graph.cpp
+++ b/lib/constraint_graph.cpp
@@ -348,6 +348,7 @@ BOOL csp_solution_iteration(
     return changed;
 }
 
+#ifndef __OPENCL_C_VERSION__
 BOOL solve_csp(struct ConstraintGraph* graph)
 {
     BOOL changed = TRUE;
@@ -367,6 +368,7 @@ BOOL solve_csp(struct ConstraintGraph* graph)
     }
     return check_nodes_left(graph);
 }
+#endif
 
 #ifndef __OPENCL_C_VERSION__
 }

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -31,6 +31,10 @@
 
 #define TO_FLOAT(x) (static_cast<FLOAT>(x))
 
+#else
+
+#define TO_FLOAT(x) (convert_float(x))
+
 #endif
 
 #define SQR(x) ((x) * (x))

--- a/lib/disparity_graph.cpp
+++ b/lib/disparity_graph.cpp
@@ -24,13 +24,18 @@
 #include <disparity_graph.hpp>
 #include <indexing.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 #include <limits>
 #include <stdexcept>
 #include <string>
 
-#define SQR(x) ((x) * (x))
 #define TO_FLOAT(x) (static_cast<FLOAT>(x))
 
+#endif
+
+#define SQR(x) ((x) * (x))
+
+#ifndef __OPENCL_C_VERSION__
 namespace sp::graph::disparity
 {
 
@@ -162,6 +167,7 @@ DisparityGraph::DisparityGraph(
         static_cast<FLOAT>(0)
     );
 }
+#endif
 
 FLOAT edge_penalty(const struct DisparityGraph* graph, struct Edge edge)
 {
@@ -187,4 +193,6 @@ FLOAT node_penalty(const struct DisparityGraph* graph, struct Node node)
         + reparametrization_value_fast(graph, node, 3);
 }
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif

--- a/lib/gpu_csp.cpp
+++ b/lib/gpu_csp.cpp
@@ -110,8 +110,8 @@ BOOL csp_solution_cl(
         static_cast<cl_ulong>(0)
     );
 
-    ULONG x_index = static_cast<cl_ulong>(choose_best_node_gpu.arity() - 2);
-    ULONG y_index = static_cast<cl_ulong>(choose_best_node_gpu.arity() - 1);
+    auto x_index = static_cast<cl_ulong>(choose_best_node_gpu.arity() - 2);
+    auto y_index = static_cast<cl_ulong>(choose_best_node_gpu.arity() - 1);
 
     for (ULONG x = 0; x < graph->disparity_graph->right.width; ++x)
     {

--- a/lib/gpu_csp.cpp
+++ b/lib/gpu_csp.cpp
@@ -1,0 +1,146 @@
+#include <compile_cl.hpp>
+#include <gpu_csp.hpp>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace gpu
+{
+
+namespace compute = boost::compute;
+
+using boost::compute::command_queue;
+using boost::compute::kernel;
+using boost::compute::system;
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
+
+void build_csp_program(struct Problem* problem)
+{
+    problem->queue = system::default_queue();
+    problem->program = create_program(
+        SOURCE_FILES,
+        problem->queue.get_context()
+    );
+}
+
+void prepare_problem(struct ConstraintGraph* graph, struct Problem* problem)
+{
+    problem->left_image.assign(
+        graph->disparity_graph->left.data.begin(),
+        graph->disparity_graph->left.data.end(),
+        problem->queue
+    );
+    problem->right_image.assign(
+        graph->disparity_graph->right.data.begin(),
+        graph->disparity_graph->right.data.end(),
+        problem->queue
+    );
+    problem->min_penalties_pixels.assign(
+        graph->lowest_penalties->pixels.begin(),
+        graph->lowest_penalties->pixels.end(),
+        problem->queue
+    );
+    problem->min_penalties_edges.assign(
+        graph->lowest_penalties->neighborhoods.begin(),
+        graph->lowest_penalties->neighborhoods.end(),
+        problem->queue
+    );
+    problem->reparametrization.assign(
+        graph->disparity_graph->reparametrization.begin(),
+        graph->disparity_graph->reparametrization.end(),
+        problem->queue
+    );
+}
+
+BOOL csp_solution_cl(
+    struct ConstraintGraph* graph,
+    struct Problem* problem
+)
+{
+    command_queue queue = system::default_queue();
+    compute::vector<int> data(
+        graph->nodes_availability.size(),
+        problem->queue.get_context()
+    );
+
+    vector<int> tmp(graph->nodes_availability.begin(), graph->nodes_availability.end());
+    compute::vector<int> nodes_availability(tmp, problem->queue);
+    compute::vector<int> changed({0, 0}, problem->queue);
+
+    kernel csp_iteration = problem->program.create_kernel("csp_iteration");
+    csp_iteration.set_args(
+        nodes_availability.get_buffer(),
+        changed.get_buffer(),
+        problem->left_image.get_buffer(),
+        problem->right_image.get_buffer(),
+        problem->min_penalties_pixels.get_buffer(),
+        problem->min_penalties_edges.get_buffer(),
+        problem->reparametrization.get_buffer(),
+        static_cast<cl_ulong>(graph->disparity_graph->right.height),
+        static_cast<cl_ulong>(graph->disparity_graph->right.width),
+        static_cast<cl_ulong>(graph->disparity_graph->right.max_value),
+        static_cast<cl_ulong>(graph->disparity_graph->disparity_levels),
+        static_cast<cl_float>(graph->threshold),
+        static_cast<cl_float>(graph->disparity_graph->cleanness),
+        static_cast<cl_float>(graph->disparity_graph->smoothness)
+    );
+
+    kernel choose_best_node_gpu = problem->program.create_kernel(
+        "choose_best_node_gpu"
+    );
+    choose_best_node_gpu.set_args(
+        nodes_availability.get_buffer(),
+        problem->left_image.get_buffer(),
+        problem->right_image.get_buffer(),
+        problem->min_penalties_pixels.get_buffer(),
+        problem->min_penalties_edges.get_buffer(),
+        problem->reparametrization.get_buffer(),
+        static_cast<cl_ulong>(graph->disparity_graph->right.height),
+        static_cast<cl_ulong>(graph->disparity_graph->right.width),
+        static_cast<cl_ulong>(graph->disparity_graph->right.max_value),
+        static_cast<cl_ulong>(graph->disparity_graph->disparity_levels),
+        static_cast<cl_float>(graph->threshold),
+        static_cast<cl_float>(graph->disparity_graph->cleanness),
+        static_cast<cl_float>(graph->disparity_graph->smoothness),
+        static_cast<cl_ulong>(0),
+        static_cast<cl_ulong>(0)
+    );
+
+    ULONG x_index = static_cast<cl_ulong>(choose_best_node_gpu.arity() - 2);
+    ULONG y_index = static_cast<cl_ulong>(choose_best_node_gpu.arity() - 1);
+
+    for (ULONG x = 0; x < graph->disparity_graph->right.width; ++x)
+    {
+        for (ULONG y = 0; y < graph->disparity_graph->right.height; ++y)
+        {
+            choose_best_node_gpu.set_arg(x_index, x);
+            choose_best_node_gpu.set_arg(y_index, y);
+            queue.enqueue_task(choose_best_node_gpu);
+            queue.finish();
+
+            do
+            {
+                queue.enqueue_1d_range_kernel(
+                    csp_iteration,
+                    0,
+                    graph->disparity_graph->right.data.size(),
+                    0
+                );
+
+                queue.finish();
+            } while (changed[1] != 0);
+        }
+    }
+
+    graph->nodes_availability.assign(
+        nodes_availability.begin(),
+        nodes_availability.end()
+    );
+    return changed[1] != 0;
+}
+
+}

--- a/lib/image.cpp
+++ b/lib/image.cpp
@@ -23,8 +23,10 @@
  */
 #include <image.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 namespace sp::image
 {
+#endif
 
 BOOL image_valid(const struct Image* image)
 {
@@ -42,4 +44,6 @@ BOOL image_valid(const struct Image* image)
     return true;
 }
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif

--- a/lib/indexing.cpp
+++ b/lib/indexing.cpp
@@ -24,10 +24,12 @@
 #include <disparity_graph.hpp>
 #include <indexing.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 namespace sp::indexing
 {
 
 using sp::graph::disparity::NEIGHBORS_COUNT;
+#endif
 
 ULONG pixel_index(const struct Image* image, struct Pixel pixel)
 {
@@ -204,4 +206,6 @@ struct Pixel neighbor_by_index(
     return pixel;
 }
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif

--- a/lib/indexing_checks.cpp
+++ b/lib/indexing_checks.cpp
@@ -24,10 +24,12 @@
 #include <indexing.hpp>
 #include <indexing_checks.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 namespace sp::indexing::checks
 {
 
 using sp::types::FLOAT;
+#endif
 
 bool neighborhood_exists(
     const struct DisparityGraph* graph,
@@ -108,4 +110,6 @@ bool edge_exists(
     return true;
 }
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -26,7 +26,9 @@
 #include <labeling_finder.hpp>
 
 #ifndef __OPENCL_C_VERSION__
+#ifdef USE_OPENCL
 #include <gpu_csp.hpp>
+#endif
 
 #include <algorithm>
 #include <iostream>
@@ -44,7 +46,9 @@ using sp::types::BOOL;
 using sp::types::Node;
 using sp::types::ULONG;
 using sp::types::ULONG_ARRAY;
+#ifdef USE_OPENCL
 using gpu::csp_solution_cl;
+#endif
 using std::back_inserter;
 using std::logic_error;
 using std::merge;
@@ -305,6 +309,7 @@ struct ConstraintGraph* choose_best_node(
 }
 
 #ifndef __OPENCL_C_VERSION__
+#ifdef USE_OPENCL
 struct ConstraintGraph* find_labeling_cl(
     struct ConstraintGraph* graph
 )
@@ -315,6 +320,7 @@ struct ConstraintGraph* find_labeling_cl(
     gpu::csp_solution_cl(graph, &problem);
     return graph;
 }
+#endif
 
 struct ConstraintGraph* find_labeling(
     struct ConstraintGraph* graph

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -25,7 +25,9 @@
 #include <indexing_checks.hpp>
 #include <labeling_finder.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 #include <algorithm>
+#include <iostream>
 #include <iterator>
 #include <stdexcept>
 
@@ -236,6 +238,7 @@ FLOAT calculate_minimal_consistent_threshold(
     }
     return available_penalties[current_index];
 }
+#endif
 
 struct ConstraintGraph* choose_best_node(
     struct ConstraintGraph* graph,
@@ -298,6 +301,7 @@ struct ConstraintGraph* choose_best_node(
     return node_chosen? graph : NULL;
 }
 
+#ifndef __OPENCL_C_VERSION__
 struct ConstraintGraph* find_labeling(
     struct ConstraintGraph* graph
 )
@@ -392,3 +396,4 @@ struct Image build_disparity_map(
 }
 
 }
+#endif

--- a/lib/labeling_finder.cpp
+++ b/lib/labeling_finder.cpp
@@ -26,6 +26,8 @@
 #include <labeling_finder.hpp>
 
 #ifndef __OPENCL_C_VERSION__
+#include <gpu_csp.hpp>
+
 #include <algorithm>
 #include <iostream>
 #include <iterator>
@@ -42,6 +44,7 @@ using sp::types::BOOL;
 using sp::types::Node;
 using sp::types::ULONG;
 using sp::types::ULONG_ARRAY;
+using gpu::csp_solution_cl;
 using std::back_inserter;
 using std::logic_error;
 using std::merge;
@@ -302,6 +305,17 @@ struct ConstraintGraph* choose_best_node(
 }
 
 #ifndef __OPENCL_C_VERSION__
+struct ConstraintGraph* find_labeling_cl(
+    struct ConstraintGraph* graph
+)
+{
+    struct gpu::Problem problem;
+    build_csp_program(&problem);
+    prepare_problem(graph, &problem);
+    gpu::csp_solution_cl(graph, &problem);
+    return graph;
+}
+
 struct ConstraintGraph* find_labeling(
     struct ConstraintGraph* graph
 )

--- a/lib/lowest_penalties.cpp
+++ b/lib/lowest_penalties.cpp
@@ -24,6 +24,7 @@
 #include <indexing_checks.hpp>
 #include <lowest_penalties.hpp>
 
+#ifndef __OPENCL_C_VERSION__
 namespace sp::graph::lowest_penalties
 {
 
@@ -87,6 +88,7 @@ LowestPenalties::LowestPenalties(const struct DisparityGraph* graph)
         }
     }
 }
+#endif
 
 FLOAT calculate_lowest_pixel_penalty(
     const struct DisparityGraph* graph,
@@ -222,4 +224,6 @@ FLOAT lowest_neighborhood_penalty(
     ];
 }
 
+#ifndef __OPENCL_C_VERSION__
 }
+#endif

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -2,11 +2,13 @@
 
 #include <constraint_graph.hpp>
 #include <disparity_graph.hpp>
+#include <gpu_csp.hpp>
 #include <image.hpp>
 #include <labeling_finder.hpp>
 #include <lowest_penalties.hpp>
 #include <pgm_io.hpp>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -15,11 +17,20 @@
 
 struct sp::image::Image read_image(const std::string& image_path);
 
+enum Parallelism
+{
+    CPU,
+    OpenCL,
+};
+
 int main(int argc, char* argv[]) try
 {
     boost::program_options::options_description desc("Allowed options");
     desc.add_options()
         ("help,h", "Help message")
+        ("parallel,p",
+         boost::program_options::value<std::string>(),
+         "Choose the paralleling technology: OMP, CL")
         ("left-image,l",
          boost::program_options::value<std::string>(),
          "Left image")
@@ -64,6 +75,41 @@ int main(int argc, char* argv[]) try
         && vm.count("right-image") == 1
     )
     {
+        Parallelism parallelism;
+        if (vm.count("parallel") == 0)
+        {
+            parallelism = Parallelism::CPU;
+        }
+        else
+        {
+            std::string parallelism_input = vm["parallel"].as<std::string>();
+            std::transform(
+                parallelism_input.begin(),
+                parallelism_input.end(),
+                parallelism_input.begin(),
+                (int (*)(int))std::tolower
+            );
+            if (parallelism_input == "cl" || parallelism_input == "opencl")
+            {
+                parallelism = Parallelism::OpenCL;
+                    std::cout << "OpenCL parallelism" << std::endl;
+            }
+            else if (
+                parallelism_input == "cpu"
+                || parallelism_input == "openmp"
+                || parallelism_input == "omp"
+            )
+            {
+                    parallelism = Parallelism::CPU;
+                    std::cout << "OpenMP parallelism" << std::endl;
+            }
+            else
+            {
+                throw std::invalid_argument(
+                    "`parallel` cannot be " + vm["parallel"].as<std::string>() + "."
+                );
+            }
+        }
         try
         {
             struct sp::image::Image left_image{
@@ -129,10 +175,28 @@ int main(int argc, char* argv[]) try
                     "Refer to the developers."
                 );
             }
-            if (
-                sp::labeling::finder::find_labeling(&constraint_graph)
-                == nullptr
-            )
+
+            struct sp::graph::constraint::ConstraintGraph* labeled_graph = nullptr;
+            switch (parallelism)
+            {
+                case Parallelism::CPU:
+                    labeled_graph = sp::labeling::finder::find_labeling(
+                        &constraint_graph
+                    );
+                    break;
+                case Parallelism::OpenCL:
+                    labeled_graph = sp::labeling::finder::find_labeling_cl(
+                        &constraint_graph
+                    );
+                    break;
+                default:
+                    throw std::logic_error(
+                        "Unknown parallelism schema. "
+                        "This should not ever happen. "
+                        "Refer to the developers."
+                    );
+            }
+            if (labeled_graph == nullptr)
             {
                 throw std::logic_error(
                     "Cannot find labeling. "

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) try
                 parallelism_input.begin(),
                 parallelism_input.end(),
                 parallelism_input.begin(),
-                (int (*)(int))std::tolower
+                [](unsigned char c){ return std::tolower(c)
             );
 #ifdef USE_OPENCL
             if (parallelism_input == "cl" || parallelism_input == "opencl")

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -2,7 +2,9 @@
 
 #include <constraint_graph.hpp>
 #include <disparity_graph.hpp>
+#ifdef USE_OPENCL
 #include <gpu_csp.hpp>
+#endif
 #include <image.hpp>
 #include <labeling_finder.hpp>
 #include <lowest_penalties.hpp>
@@ -20,7 +22,9 @@ struct sp::image::Image read_image(const std::string& image_path);
 enum Parallelism
 {
     CPU,
+#ifdef USE_OPENCL
     OpenCL,
+#endif
 };
 
 int main(int argc, char* argv[]) try
@@ -89,12 +93,15 @@ int main(int argc, char* argv[]) try
                 parallelism_input.begin(),
                 (int (*)(int))std::tolower
             );
+#ifdef USE_OPENCL
             if (parallelism_input == "cl" || parallelism_input == "opencl")
             {
                 parallelism = Parallelism::OpenCL;
                     std::cout << "OpenCL parallelism" << std::endl;
             }
-            else if (
+            else
+#endif
+            if (
                 parallelism_input == "cpu"
                 || parallelism_input == "openmp"
                 || parallelism_input == "omp"
@@ -184,11 +191,13 @@ int main(int argc, char* argv[]) try
                         &constraint_graph
                     );
                     break;
+#ifdef USE_OPENCL
                 case Parallelism::OpenCL:
                     labeled_graph = sp::labeling::finder::find_labeling_cl(
                         &constraint_graph
                     );
                     break;
+#endif
                 default:
                     throw std::logic_error(
                         "Unknown parallelism schema. "

--- a/lib/main.cpp
+++ b/lib/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) try
                 parallelism_input.begin(),
                 parallelism_input.end(),
                 parallelism_input.begin(),
-                [](unsigned char c){ return std::tolower(c)
+                [](unsigned char c){ return std::tolower(c); }
             );
 #ifdef USE_OPENCL
             if (parallelism_input == "cl" || parallelism_input == "opencl")

--- a/lib/solve_csp.cl
+++ b/lib/solve_csp.cl
@@ -1,0 +1,176 @@
+#include <types.hpp>
+#include <constraint_graph.hpp>
+#include <lowest_penalties.hpp>
+#include <labeling_finder.hpp>
+#include <disparity_graph.hpp>
+#include <image.hpp>
+#include <indexing_checks.hpp>
+#include <indexing.hpp>
+
+void populate_structures_gpu(
+    struct DisparityGraph* disparity_graph,
+    struct LowestPenalties* lowest_penalties,
+    struct ConstraintGraph* constraint_graph,
+    __global int* nodes_availability,
+    __global ulong* left_image,
+    __global ulong* right_image,
+    __global float* min_penalties_pixels,
+    __global float* min_penalties_edges,
+    __global float* reparametrization,
+    ulong height,
+    ulong width,
+    ulong max_value,
+    ulong disparity_levels,
+    float threshold,
+    float cleanness,
+    float smoothness
+)
+{
+    disparity_graph->left.data = left_image;
+    disparity_graph->left.height = height;
+    disparity_graph->left.max_value = max_value;
+    disparity_graph->left.width = width;
+
+    disparity_graph->right.data = right_image;
+    disparity_graph->right.height = height;
+    disparity_graph->right.max_value = max_value;
+    disparity_graph->right.width = width;
+
+    disparity_graph->cleanness = cleanness;
+    disparity_graph->disparity_levels = disparity_levels;
+    disparity_graph->reparametrization = reparametrization;
+    disparity_graph->smoothness = smoothness;
+
+    lowest_penalties->graph = disparity_graph;
+    lowest_penalties->pixels = min_penalties_pixels;
+    lowest_penalties->neighborhoods = min_penalties_edges;
+
+    constraint_graph->threshold = threshold;
+    constraint_graph->nodes_availability = nodes_availability;
+    constraint_graph->lowest_penalties = lowest_penalties;
+    constraint_graph->disparity_graph = disparity_graph;
+}
+
+void csp_solution_iteration_gpu(
+    struct ConstraintGraph* constraint_graph,
+    struct Pixel pixel,
+    __global int* changed_step,
+    __global int* changed_any
+)
+{
+    do
+    {
+        *changed_step = 0;
+        barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
+        if (csp_process_pixel(constraint_graph, pixel))
+        {
+            *changed_step = 1;
+            *changed_any = 1;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
+    } while (*changed_step);
+}
+
+__kernel void csp_iteration(
+    __global int* nodes_availability,
+    __global int* changed,
+    __global ulong* left_image,
+    __global ulong* right_image,
+    __global float* min_penalties_pixels,
+    __global float* min_penalties_edges,
+    __global float* reparametrization,
+    ulong height,
+    ulong width,
+    ulong max_value,
+    ulong disparity_levels,
+    float threshold,
+    float cleanness,
+    float smoothness
+)
+{
+    ulong thread_id = get_global_id(0);
+
+    struct DisparityGraph disparity_graph;
+    struct LowestPenalties lowest_penalties;
+    struct ConstraintGraph constraint_graph;
+
+    populate_structures_gpu(
+        &disparity_graph,
+        &lowest_penalties,
+        &constraint_graph,
+        nodes_availability,
+        left_image,
+        right_image,
+        min_penalties_pixels,
+        min_penalties_edges,
+        reparametrization,
+        height,
+        width,
+        max_value,
+        disparity_levels,
+        threshold,
+        cleanness,
+        smoothness
+    );
+
+    atomic_and(&changed[0], 0);
+    atomic_and(&changed[1], 0);
+
+    struct Pixel pixel;
+    pixel.x = thread_id % constraint_graph.disparity_graph->right.width;
+    pixel.y = thread_id / constraint_graph.disparity_graph->right.width;
+
+    csp_solution_iteration_gpu(
+        &constraint_graph,
+        pixel,
+        &changed[0],
+        &changed[1]
+    );
+}
+
+__kernel void choose_best_node_gpu(
+    __global int* nodes_availability,
+    __global ulong* left_image,
+    __global ulong* right_image,
+    __global float* min_penalties_pixels,
+    __global float* min_penalties_edges,
+    __global float* reparametrization,
+    ulong height,
+    ulong width,
+    ulong max_value,
+    ulong disparity_levels,
+    float threshold,
+    float cleanness,
+    float smoothness,
+    ulong pixel_x,
+    ulong pixel_y
+)
+{
+    struct DisparityGraph disparity_graph;
+    struct LowestPenalties lowest_penalties;
+    struct ConstraintGraph constraint_graph;
+
+    populate_structures_gpu(
+        &disparity_graph,
+        &lowest_penalties,
+        &constraint_graph,
+        nodes_availability,
+        left_image,
+        right_image,
+        min_penalties_pixels,
+        min_penalties_edges,
+        reparametrization,
+        height,
+        width,
+        max_value,
+        disparity_levels,
+        threshold,
+        cleanness,
+        smoothness
+    );
+
+    struct Pixel pixel;
+    pixel.x = pixel_x;
+    pixel.y = pixel_y;
+    choose_best_node(&constraint_graph, pixel);
+}


### PR DESCRIPTION
# OpenCL code explained

I should definitely explain what I do here,
because this was hard for me to understand first,
and I want this commit to be helpful for someone who writes OpenCL code.

## High-level overview

First, I should transfer the data from the RAM to the VRAM
(memory of the video card).
If you use OpenCL for your CPU,
you still need to create a special entity called `Buffer`
and copy data there.
Though, as I understand,
there is a flag,
allowing you to pass the pointer and use the data directly.
I didn't use it, so will not explain it in details.
Thus, I cannot pass classes to GPU memory.
I should provide arrays and numbers instead.
I create `struct Problem` to store the needed information.
Maybe it will become a class in the future,
but now I'm too lazy to manage this.
I just want to make this commit and move on.
Buffers are managed easily with Boost.Compute:
you just create a vector-like entity `boost::compute::vector<T>`
and copy your data there via `assign` member function.
Note that you should cast the type.
You can assign types like `int`, `float` and `double`
to `cl_int` and `cl_float` withoug any problems,
but there is an issue with `bool` vector;
first, I create a `std::vector<int>`,
copy my `std::vector<bool>` there via `assign`,
and then copy the `std::vector<int>` to the `boost::compute::vector<cl_int>`.
Read the #Boost.Compute section to know more.

Second, I need to build the OpenCL program.
It cannot be built in such familiar ways like CUDA or an ordinary C++ code
via compiler.
You should build the source code from a string (`char*` or `std::string`).
So, if you want to have modularity,
you should read all files, concatenate them into a string,
and build the program.
This makes debugging messy.
Also, the application should know paths to sources at the runtime to read them.
As far as I know, nVidia devices don't support OpenCL 2 at the moment.
So, I have to compile the code using OpenCL 1.2.

Third, I need to call the functions on GPU.
Not so fast.
Even though you've built the program,
you didn't specify the entry point.
Surprise!
We have special functions marked by `__kernel` specifier.
These are potential entry points.
I should call `create_kernel` function to create an instance
that can call the entry point.
Then, I provide all needed arguments to the kernel
via `set_args` member function.
Much more convenient than with pure OpenCL API.
I can provide buffers and numbers.
It's better to use `static_cast` to `cl_*` types for numbers
in order to be sure that the types are right.
I've used `FLOAT` which is `double` in my code,
and the API doesn't make the conversion.
Instead, it knows that the `double` has the size `8`,
and `cl_float` (`float` type used for argument in my kernel)
has the size `4`.
As a result, I've got the error regarding the size mismatch.
I can change arguments of the caller in runtime,
so I don't need to create a new one
to go to another row or column of the image.
I just change the `x` and `y` arguments at the caller
and call the kernel with new parameters.
At least, let's call the kernel!
If it should have only one thread,
I can call it using `enqueue_task`.
Call `queue.finish()` to wait until it's finished.
When I want to create many threads (one per pixel),
I call `enqueue_1d_range_kernel`
and specify the image size.
I use one-dimensional arrays for efficiency
(didn't really check the efficiency yet).
Within the kernel, the thread identifier is available.
It's equal to a number from `0` to the index of the last pixel,
so I can use it easily.

Fourth, the synchronization.
OpenCL has the `barrier` synchronization primitive.
Though, it works only within so-called workgroups.
A workgroup is a bunch of threads.
This means that if I call the `barrier` in the code,
it will wait for all threads in a group.
I still use the `barrier` inside the kernel
to synchronize threads as much as I can.
It's impossible to synchronize all threads
using default OpenCL abilities
https://stackoverflow.com/a/5895183/1305036
https://stackoverflow.com/a/6899015/1305036
That's why I provide a global array called `changed`.
All threads have access to it,
and they change the value of its specific element to `1`
when they change anything.
Don't forget to use `atomic_and` and `atomic_or` operations
to do things correctly.
If you do `*a = 0` without atomic,
another thread may still use the cached old value
and behave wrong.
As a result,
after the kernel execution on all threads, I know
whether something was changed.
If it was, I should run the kernel again.

Fifth, read the result using `assign` of the `std::vector`.
Cloning information from `boost::compute::vector<cl_int>` to `std:;vector<bool>`
is easy and can be done without problems, unlike vice versa.

# My basic errors

## Invalid context

I've got `CL_INVALID_CONTEXT` error.
It's appeared that I forgot to build a `struct Program`,
so I didn't have a context at all.
The GPU code execution function
should have validation of input parameters.

## Invalid kernel name

The `CL_INVALID_KERNEL_NAME` error occurs
when specified kernel (main function)
was not found in the GPU code.
My code reads GPU code from files,
using paths relative to the folder,
from which the user executes the application
(not the application folder itself).
When we go to the `build` directory
and call tests from it using `ctest`,
the application cannot find any files
specified for the GPU execution.
Here are possible solutions
http://people.cs.bris.ac.uk/~simonm/montblanc/AdvancedOpenCL_full.pdf
https://softwareengineering.stackexchange.com/q/313385/322539
but there is no native one.
I should combine all GPU files into one string
and use it in my code to not have problems with relative paths.
Note that if you want to protect your OpenCL code from copying,
this method will work really bad for you.
Embedding of binary code will not work too,
because it's compiled for a device it's compiled on.
You can use an encryption algorithm,
but the decrypted string can be caught
on the kernel creation stage.
My code is very open source,
so I don't have such problems:
I probably have to create a script to gather all GPU code,
call it during the build,
and use the created file.
Maybe it will be a separate shared library.

## Read-only variable assignment

When I tried to write building of graphs in the GPU kernel,
I thought that it would be enough to not create a separate disparity graph,
but to use the existing lowest penalties graph.

Though, I've got the following errors when tried to use it

```
--- build log ---
<kernel>:1649:40: error: read-only variable is not assignable
    lowest_penalties->graph->left.data = left_image;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1650:42: error: read-only variable is not assignable
    lowest_penalties->graph->left.height = height;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1651:45: error: read-only variable is not assignable
    lowest_penalties->graph->left.max_value = max_value;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1652:41: error: read-only variable is not assignable
    lowest_penalties->graph->left.width = width;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1654:41: error: read-only variable is not assignable
    lowest_penalties->graph->right.data = right_image;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1655:43: error: read-only variable is not assignable
    lowest_penalties->graph->right.height = height;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1656:46: error: read-only variable is not assignable
    lowest_penalties->graph->right.max_value = max_value;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1657:42: error: read-only variable is not assignable
    lowest_penalties->graph->right.width = width;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1659:40: error: read-only variable is not assignable
    lowest_penalties->graph->cleanness = cleanness;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1660:47: error: read-only variable is not assignable
    lowest_penalties->graph->disparity_levels = disparity_levels;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1661:48: error: read-only variable is not assignable
    lowest_penalties->graph->reparametrization = reparametrization;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
<kernel>:1662:41: error: read-only variable is not assignable
    lowest_penalties->graph->smoothness = smoothness;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
```

Oh lord. The `graph` property of the `struct LowestPenalties`
is a pointer, which is `NULL` by default if we're lucky!
Maybe this is the issue.
If I initialize the graph in the function, I will have serious problems
because of variable lifetime
(the graph will be removed after the function finish).
So, I should prepare the graph beforehand.
It's easier to require these three graphs to be passed to the function
instead of depending on my memory and asking me to create those graphs
and link them together before the function call.

## Travis CI build fails

### Failed to install `llvm-6.0 clang-6.0`

My builds started to fail with
```
The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install llvm-6.0 clang-6.0" failed and exited with 100 during .
```
https://travis-ci.org/char-lie/stereo-parallel/jobs/581336946

Default Travis CI Ubuntu version is now Xenial 16.04.
So, I don't need to use  `llvm-toolchain-trusty-x.0`,
`sourceline: 'ppa:ubuntu-toolchain-r/test'` and `llvm-6.0`.
It's enough to use `ubuntu-toolchain-r-test` in `sources`.

### Clang static analizer fails with `recipe for target 'lib/CMakeFiles/...' failed`

The cause of the fail is not specified
```
Error while processing /home/travis/build/char-lie/stereo-parallel/build/lib/.
1391 warnings and 1 error generated.
Error while processing /home/travis/build/char-lie/stereo-parallel/lib/image.cpp.
Suppressed 1385 warnings (1385 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
Found compiler error(s).
lib/CMakeFiles/image.dir/build.make:62: recipe for target 'lib/CMakeFiles/image.dir/image.cpp.o' failed
make[2]: *** [lib/CMakeFiles/image.dir/image.cpp.o] Error 1
CMakeFiles/Makefile2:384: recipe for target 'lib/CMakeFiles/image.dir/all' failed
make[1]: *** [lib/CMakeFiles/image.dir/all] Error 2
Makefile:94: recipe for target 'all' failed
make: *** [all] Error 2
```
https://travis-ci.org/char-lie/stereo-parallel/jobs/581550114

There are no answers at the moment
https://stackoverflow.com/q/57817923/1305036

Using `make .` instead of `cmake --build .` fixes the problem, but why?
`make` and `make all` doesn't work &mdash; only `make .`.
Mystery.

# Boost.Compute

## Introduction

There is an interesting library Boost.Compute.
It provides a convenient interface to call OpenCL kernels,
convert data between host and client (CPU and GPU) memory,
and has a bunch of interesting functions
https://github.com/boostorg/compute
It's said that the library is header-only,
so no linking required (no need to change `CMakeLists.txt`?).
Though, on Ubuntu 16.04 (xenial) there is a separate package
called `libcompute-dev`
https://packages.ubuntu.com/source/xenial/compute
This slideshow may help to get familiar with the library
https://www.iwocl.org/wp-content/uploads/iwocl-2016-boost-compute.pdf
Should I use it instead of raw `cl.hpp`,
own errors handling and data transfer?

The library is available from Boost 1.61.0
https://www.boost.org/doc/libs

## Documentation

It's complicated enough to build the application using the `Boost.Compute`
because of lack of documentation.
I use this document to begin
https://www.iwocl.org/wp-content/uploads/iwocl-2016-boost-compute.pdf
Where to get the `queue`? Here!
http://boostorg.github.io/compute/boost_compute/tutorial.html#boost_compute.tutorial.transferring_data
Okay. I don't want to use the named cache. I want to build my program.
Simply call `build_with_source`,
In order to read the log in the case of failure,
I have to use kernel debug mode by defining

```
#define BOOST_COMPUTE_DEBUG_KERNEL_COMPILATION
```

Here is the documentation
https://boostorg.github.io/compute/boost/compute/program.html
The table with correspondence between OpenCL and Boost.Compute terms
may help
https://www.boost.org/doc/libs/1_65_0/libs/compute/doc/html/boost_compute/porting_guide.html

Parameters for building programs are here
https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clBuildProgram.html

## Goodbye `cl::Buffer`, hail the `bost::compute::vector`!

The `boost::compute::vector` is a miracle:
now I have a very convenient interface
for converting it from and to `std::vector`,
and I don't need to care about reading and writing to and from `cl::Buffer`:
when my kernel makes changes to buffer bound to `boost::compute::vector`,
I can get freshly updated elements from it.

## Typecast issue: `bool` -> `cl_int`

The code

```
compute::vector<int> nodes_availability(
	graph->nodes_availability.begin(),
	graph->nodes_availability.end(),
	problem->queue
);
```

causes the error

```
In file included from .../stereo-parallel/lib/gpu_csp.cpp:1:
In file included from .../stereo-parallel/include/compile_cl.hpp:12:
In file included from /usr/include/boost/compute.hpp:14:
In file included from /usr/include/boost/compute/algorithm.hpp:18:
In file included from /usr/include/boost/compute/algorithm/accumulate.hpp:19:
In file included from /usr/include/boost/compute/algorithm/reduce.hpp:20:
In file included from /usr/include/boost/compute/container/array.hpp:23:
In file included from /usr/include/boost/compute/algorithm/fill.hpp:24:
/usr/include/boost/compute/algorithm/copy.hpp:164:13: error: call to deleted function 'addressof'
            ::boost::addressof(*first)
            ^~~~~~~~~~~~~~~~~~
/usr/include/boost/compute/algorithm/copy.hpp:278:12: note: in instantiation of function template specialization 'boost::compute::detail::dispatch_copy_async<std::_Bit_iterator,
      boost::compute::buffer_iterator<int> >' requested here
    return dispatch_copy_async(first, last, result, queue).get();
           ^
/usr/include/boost/compute/algorithm/copy.hpp:838:20: note: in instantiation of function template specialization 'boost::compute::detail::dispatch_copy<std::_Bit_iterator, boost::compute::buffer_iterator<int> >$
      requested here
    return detail::dispatch_copy(first, last, result, queue);
                   ^
/usr/include/boost/compute/container/vector.hpp:187:27: note: in instantiation of function template specialization 'boost::compute::copy<std::_Bit_iterator, boost::compute::buffer_iterator<int> >' requested her$
        ::boost::compute::copy(first, last, begin(), queue);
                          ^
.../stereo-parallel/lib/gpu_csp.cpp:141:26: note: in instantiation of function template specialization 'boost::compute::vector<int, boost::compute::buffer_allocator<int>
      >::vector<std::_Bit_iterator>' requested here
    compute::vector<int> nodes_availability(
                         ^
/usr/include/boost/core/addressof.hpp:269:10: note: candidate function [with T = std::_Bit_reference] has been explicitly deleted
const T* addressof(const T&&) = delete;
         ^
/usr/include/boost/core/addressof.hpp:38:1: note: candidate function [with T = std::_Bit_reference] not viable: expects an l-value for 1st argument
addressof(T& o) BOOST_NOEXCEPT
^
In file included from .../stereo-parallel/lib/gpu_csp.cpp:1:                                                                                                                                         In file included from .../stereo-parallel/include/compile_cl.hpp:12:                                                                                                                                 In file included from /usr/include/boost/compute.hpp:14:
In file included from /usr/include/boost/compute/algorithm.hpp:18:
In file included from /usr/include/boost/compute/algorithm/accumulate.hpp:19:
In file included from /usr/include/boost/compute/algorithm/reduce.hpp:20:
In file included from /usr/include/boost/compute/container/array.hpp:23:
In file included from /usr/include/boost/compute/algorithm/fill.hpp:24:
/usr/include/boost/compute/algorithm/copy.hpp:163:9: error: const_cast from 'const std::_Bit_reference *' to 'const input_type *' (aka 'const bool *') is not allowed
        const_cast<const input_type*>(
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

First, I tried to find the issue with `error: call to deleted function 'addressof'`
https://stackoverflow.com/a/45670806/1305036
Further googling gave no additional information to me,
so I've decided to read the end of the error message,
and found
`error: const_cast from 'const std::_Bit_reference *' to 'const input_type *' (aka 'const bool *') is not allowed`
Oh yes! So, I should have cast the `bool` vector to the `int` by myself
and only then put it to the buffer,
because OpenCL doesn't have `bool` type.
The problem of conversion from `bool` to `int`,
as I can think from the error message,
is that in C++ there is a template specialization for `std::vector<bool>`
https://en.cppreference.com/w/cpp/container/vector_bool

## Use `cl_float` to avoid `Invalid argument size`

The next issue was `Invalid Argument Size`, a. k. a. `CL_INVALID_ARG_SIZE`.
First, I've confused it with `Invalid Arguments Index`,
a. k. a. `CL_INVALID_ARG_INDEX`,
so I've counted number of arguments multiple times.
Then I've reread the error and found the answer here
https://stackoverflow.com/q/36946420/1305036
Aha! I use `FLOAT`, which is `double`,
and its size is `8` on my machine.
Though, the kernel has `float` type of size `4`.
I've changed `FLOAT` in my `struct Problem` to `cl_float`,
`ULONG` to `cl_ulong`,
and casted numbers to `cl_float` and `cl_ulong`.
Now it works, even faster than before (`13` seconds against `20`).
Before I used pure OpenCL API, now I use `Boost.Compute`.
I didn't use `assign` function for some reason
(because I'm not smart enough?),
and created a temporary array by providing `begin` and `end`
of the result to its constructor.
Then, I've moved it to the `nodes_availability` array
of the graph.
Now, I use `assign` and the code works `10`-`11` seconds.
A miracle!

# Why do I don't want to use native OpenCL API?

## OpenCL exceptions handling

If I want to use catch OpenCL exceptions,
I should

```
#define __CL_ENABLE_EXCEPTIONS
```

because otherwise, I'll get

```
.../stereo-parallel/lib/compile_cl.cpp:21:11: error: no member named 'Error' in namespace 'cl'
using cl::Error;
      ~~~~^
.../stereo-parallel/lib/compile_cl.cpp:61:12: error: unknown type name 'Error'
    catch (Error& e)
           ^
```

## OpenCL error codes

Okay, I've caught the exception.
I will have `error.err()` with something like `-52`.
Wow, so descriptive.
Maybe I'll find the explanation of this code in documentation?
https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/errors.html
https://www.khronos.org/registry/OpenCL/specs/2.2/html/OpenCL_API.html
No.
I can find those macros in `CL/cl.h`! Cool!
I can find them on the Web
https://streamhpc.com/blog/2013-04-28/opencl-error-codes/
Here is the salvation
https://stackoverflow.com/a/44612662/1305036
I can use a special Python script
to generate a translator for error messages
https://github.com/WanghongLin/miscellaneous/blob/master/tools/clext.py
We've got `82` lines of `switch-case-default` code
just to show the error name.

## OpenCL error log

Why is it so important to distinguish between OpenCL and other types of errors?
I will see the exception name and (at least) brief information, right?
Isn't that enough?
No, I'm wrong.

If I have a problem in the kernel itself, I'll get only `CL_BUILD_ERROR`
without a lot of text (something like "Failed to build").
What should I do?
Catch the exception by myself!
Then, I have to show the log by myself again.
https://stackoverflow.com/a/34662623/1305036
`15` lines of code to see the log.

## The code before `Boost.Compute`

I'm not familiar with OpenCL too much,
so the code is awful, contains comments and debug code.
Though I think that my code may be useful for someone.
At least for me, if I will need to use the OpenCL API.

### Prepare buffers

First, I need to convert all my arrays to proper type:
use `cl_` types like `cl_ulong` and `cl_float`
instead of `unsigned` and `double`.
Then, I have to load the data into `cl::Buffer` objects.

```
void prepare_problem(struct ConstraintGraph* graph, struct Problem* problem)
{
    vector<cl_ulong> left_image(
        graph->disparity_graph->left.data.begin(),
        graph->disparity_graph->left.data.end()
    );
    vector<cl_ulong> right_image(
        graph->disparity_graph->right.data.begin(),
        graph->disparity_graph->right.data.end()
    );
    vector<cl_float> min_penalties_pixels(
        graph->lowest_penalties->pixels.begin(),
        graph->lowest_penalties->pixels.end()
    );
    vector<cl_float> min_penalties_edges(
        graph->lowest_penalties->neighborhoods.begin(),
        graph->lowest_penalties->neighborhoods.end()
    );
    vector<cl_float> reparametrization(
        graph->disparity_graph->reparametrization.begin(),
        graph->disparity_graph->reparametrization.end()
    );

    problem->left_image_buffer = Buffer(
        problem->context,
        CL_MEM_READ_ONLY | CL_MEM_HOST_NO_ACCESS | CL_MEM_COPY_HOST_PTR,
        sizeof(cl_ulong) * left_image.size(),
        left_image.data()
    );
    problem->right_image_buffer = Buffer(
        problem->context,
        CL_MEM_READ_ONLY | CL_MEM_HOST_NO_ACCESS | CL_MEM_COPY_HOST_PTR,
        sizeof(cl_ulong) * right_image.size(),
        right_image.data()
    );
    problem->min_penalties_pixels_buffer = Buffer(
        problem->context,
        CL_MEM_READ_ONLY | CL_MEM_HOST_NO_ACCESS | CL_MEM_COPY_HOST_PTR,
        sizeof(cl_float) * min_penalties_pixels.size(),
        min_penalties_pixels.data()
    );
    problem->min_penalties_edges_buffer = Buffer(
        problem->context,
        CL_MEM_READ_ONLY | CL_MEM_HOST_NO_ACCESS | CL_MEM_COPY_HOST_PTR,
        sizeof(cl_float) * min_penalties_edges.size(),
        min_penalties_edges.data()
    );
    problem->reparametrization_buffer = Buffer(
        problem->context,
        CL_MEM_READ_ONLY | CL_MEM_HOST_NO_ACCESS | CL_MEM_COPY_HOST_PTR,
        sizeof(cl_float) * reparametrization.size(),
        reparametrization.data()
    );
}
```

How to specify flags like
`CL_MEM_READ_ONLY | CL_MEM_HOST_NO_ACCESS | CL_MEM_COPY_HOST_PTR`
using `Boost.Compute`?
The `boost::compute::vector`
http://boostorg.github.io/compute/boost/compute/vector.html
uses `boost::compute::buffer_allocator` by default
http://boostorg.github.io/compute/boost/compute/buffer_allocator.html
From the source code, we can see that the constructor of the allocator
sets assigns `buffer::read_write` to `m_mem_flags`
https://github.com/boostorg/compute/blob/6c2a360/include/boost/compute/allocator/buffer_allocator.hpp
This, obviously, means `CL_MEM_READ_WRITE`
http://boostorg.github.io/compute/boost/compute/memory_object.html
I don't want to write my own allocator
and don't really need it at the moment.
Let it be `CL_MEM_READ_WRITE`, which is the default value
https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clCreateBuffer.html

### Kernel call

This part is very complicated for me,
because needs a lot of things
that can be done under the hood (in my opinion).
Though, they are in `Boost.Compute`.

```
BOOL csp_solution_iteration_gpu(
    struct ConstraintGraph* graph,
    struct Problem* problem
)
{
    vector<cl_int> data(graph->nodes_availability.size());

    try
    {

        vector<cl_int> nodes_availability(
            graph->nodes_availability.begin(),
            graph->nodes_availability.end()
        );
        vector<cl_int> changed{0, 0, 0, 0};

        Buffer changed_buffer(
            problem->context,
            CL_MEM_WRITE_ONLY | CL_MEM_HOST_READ_ONLY,
            sizeof(cl_int) * changed.size()
        );
        Buffer nodes_availability_buffer(
            problem->context,
            CL_MEM_READ_WRITE | CL_MEM_HOST_READ_ONLY | CL_MEM_COPY_HOST_PTR,
            sizeof(cl_int) * nodes_availability.size(),
            nodes_availability.data()
        );

        Kernel kernel(problem->program, "csp_iteration");
        unsigned arguments = 0;
        kernel.setArg(arguments++, nodes_availability_buffer);
        kernel.setArg(arguments++, changed_buffer);
        kernel.setArg(arguments++, problem->left_image_buffer);
        kernel.setArg(arguments++, problem->right_image_buffer);
        kernel.setArg(arguments++, problem->min_penalties_pixels_buffer);
        kernel.setArg(arguments++, problem->min_penalties_edges_buffer);
        kernel.setArg(arguments++, problem->reparametrization_buffer);
        kernel.setArg(arguments++, static_cast<const cl_ulong>(graph->disparity_graph->right.height));
        kernel.setArg(arguments++, static_cast<const cl_ulong>(graph->disparity_graph->right.width));
        kernel.setArg(arguments++, static_cast<const cl_ulong>(graph->disparity_graph->right.max_value));
        kernel.setArg(arguments++, static_cast<const cl_ulong>(graph->disparity_graph->disparity_levels));
        kernel.setArg(arguments++, static_cast<const cl_float>(graph->threshold));
        kernel.setArg(arguments++, static_cast<const cl_float>(graph->disparity_graph->cleanness));
        kernel.setArg(arguments++, static_cast<const cl_float>(graph->disparity_graph->smoothness));

        Kernel kernel_best_node(problem->program, "choose_best_node_gpu");
        unsigned arguments_best_node = 0;
        kernel_best_node.setArg(arguments_best_node++, nodes_availability_buffer);
        kernel_best_node.setArg(arguments_best_node++, changed_buffer);
        kernel_best_node.setArg(arguments_best_node++, problem->left_image_buffer);
        kernel_best_node.setArg(arguments_best_node++, problem->right_image_buffer);
        kernel_best_node.setArg(arguments_best_node++, problem->min_penalties_pixels_buffer);
        kernel_best_node.setArg(arguments_best_node++, problem->min_penalties_edges_buffer);
        kernel_best_node.setArg(arguments_best_node++, problem->reparametrization_buffer);
        kernel_best_node.setArg(arguments_best_node++, static_cast<const cl_ulong>(graph->disparity_graph->right.height));
        kernel_best_node.setArg(arguments_best_node++, static_cast<const cl_ulong>(graph->disparity_graph->right.width));
        kernel_best_node.setArg(arguments_best_node++, static_cast<const cl_ulong>(graph->disparity_graph->right.max_value));
        kernel_best_node.setArg(arguments_best_node++, static_cast<const cl_ulong>(graph->disparity_graph->disparity_levels));
        kernel_best_node.setArg(arguments_best_node++, static_cast<const cl_float>(graph->threshold));
        kernel_best_node.setArg(arguments_best_node++, static_cast<const cl_float>(graph->disparity_graph->cleanness));
        kernel_best_node.setArg(arguments_best_node++, static_cast<const cl_float>(graph->disparity_graph->smoothness));

        for (ULONG x = 0; x < graph->disparity_graph->right.width; ++x)
        {
            std::cout << "Process column " << x;
            for (ULONG y = 0; y < graph->disparity_graph->right.height; ++y)
            {
                kernel_best_node.setArg(arguments_best_node, static_cast<const cl_ulong>(x));
                kernel_best_node.setArg(arguments_best_node + 1, static_cast<const cl_ulong>(y));
                {
                    CommandQueue queue{problem->context, problem->device};
                    queue.enqueueNDRangeKernel(kernel_best_node, NullRange, NDRange(1));
                    queue.finish();
                }
                std::cout << "." << std::flush;

                do
                {
                    CommandQueue queue{problem->context, problem->device};

                    queue.enqueueNDRangeKernel(kernel, NullRange, NDRange(
                        graph->disparity_graph->right.data.size()
                    ));
                    queue.enqueueReadBuffer(
                        nodes_availability_buffer,
                        CL_FALSE,
                        0,
                        sizeof(cl_int) * data.size(),
                        data.data()
                    );
                    queue.enqueueReadBuffer(
                        changed_buffer,
                        CL_FALSE,
                        0,
                        sizeof(cl_int) * changed.size(),
                        changed.data()
                    );

                    queue.finish();
                } while (changed[1] != 0);
            }
            std::cout << std::endl;
        }

        /*
        // DEBUG information
        cout << "GPU RESULT START: " << data.size() << endl;
        ULONG result = 0;
        for (ULONG i = 0; i < data.size(); ++i)
        {
            result += static_cast<bool>(data[i]);
        }
        cout << result << " of " << (
            graph->disparity_graph->right.height
            * graph->disparity_graph->right.width
            * graph->disparity_graph->disparity_levels
        ) << endl;

        cout << "GPU RESULT SHOULD: " << graph->nodes_availability.size() << endl;
        result = 0;
        for (ULONG i = 0; i < graph->nodes_availability.size(); ++i)
        {
            result += static_cast<bool>(graph->nodes_availability[i]);
        }
        cout << result << " of " << (
            graph->disparity_graph->right.height
            * graph->disparity_graph->right.width
            * graph->disparity_graph->disparity_levels
        ) << endl;
        cout << "GPU RESULT FINISH" << endl;
        */

        vector<BOOL> new_nodes_availability(data.begin(), data.end());
        graph->nodes_availability = move(new_nodes_availability);
        return changed[1] != 0; // changed[3] != 1;
    }
    catch (Error& e)
    {
        cerr << "ERROR: " << e.what()
             << " (code " << e.err() << ", " << clGetErrorString(e.err()) << ")"
             << endl;
        throw;
    }
}
```

# General tips

## How to lowercase a string

It's crazy, but I cannot just call `my_string.upper()`.
I should use `transform`,
pass iterator to the beginning of the string,
its end, and the beginning of the string to write the result into.
In my case, the destination string is the same as the source one
https://ru.cppreference.com/w/cpp/string/byte/toupper

## How to toggle GPU code usage

I've found how to create a macro using CMake
https://stackoverflow.com/q/15201064/1305036
https://stackoverflow.com/q/30546677/1305036
I knew that this is possible from my tests configuration.
Though, I remember that there were some issues,
so I've found this thing again.
It's recommended to use `add_definitions`
https://cmake.org/cmake/help/v3.0/command/target_compile_definitions.html
As far as I understand, the `PRIVATE` keyword allows me
to create a macro, available only for the chosen module.
Now, I can use it to hide GPU code when OpenCL is not used.
